### PR TITLE
Require devutils rake to provide "publish_gem" task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "jars/installer"
 require "fileutils"
+require "logstash/devutils/rake"
 
 task :default do
   system('rake -vT')


### PR DESCRIPTION
this is needed for our internal bot jarvis to publish gems