### PR TITLE
add host info in metadata and host field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.0.beta2
+  - add host info in metadata and host field, https://github.com/logstash-plugins/logstash-input-snmp/pull/7
+
 ## 0.1.0.beta1
   - First beta version
 

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '0.1.0.beta1'
+  s.version       = '0.1.0.beta2'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Solves #6

add the polled host details in the event `@metadata` and also add the `host` field in the event using the `[@metadata][host_address]` field by default. 

`@metadata` will contain the following fields:
- `host_protocol` : will be either `udp` or `tcp`
- `host_address` :  the host  address for example `127.0.0.1`
- `host_port` : the host port for example `161`
- `host_community` : the community string for example `public`

In this plugin the `add_field` option defaults to `{ "host" => "%{[@metadata][host_address]}" }` but can be overridden to contain anything in the `@metadata` for example
```
add_field => { host => "%{[@metadata][host_protocol]}:%{[@metadata][host_address]}/%{[@metadata][host_port]},%{[@metadata][host_community]}" }
```