### PR TITLE
support tcp transport protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.0.beta3
+  - add tcp transport protocol support, https://github.com/logstash-plugins/logstash-input-snmp/pull/8
+
 ## 0.1.0.beta2
   - add host info in metadata and host field, https://github.com/logstash-plugins/logstash-input-snmp/pull/7
 

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '0.1.0.beta2'
+  s.version       = '0.1.0.beta3'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -54,13 +54,15 @@ describe LogStash::Inputs::Snmp do
           {"get" => ["1.0"], "hosts" => [{"host" => "udp:localhost/161"}]},
           {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/112345"}]},
           {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/161", "community" => "public"}]},
+          {"get" => ["1.0"], "hosts" => [{"host" => "tcp:127.0.0.1/112345"}]},
+          {"get" => ["1.0"], "hosts" => [{"host" => "tcp:127.0.0.1/161", "community" => "public"}]},
       ]
     }
 
     let(:invalid_configs) {
       [
           {"get" => ["1.0"], "hosts" => [{"host" => "aaa:127.0.0.1/161"}]},
-          {"get" => ["1.0"], "hosts" => [{"host" => "tcp:127.0.0.1/161"}]},
+          {"get" => ["1.0"], "hosts" => [{"host" => "tcp.127.0.0.1/161"}]},
           {"get" => ["1.0"], "hosts" => [{"host" => "localhost"}]},
           {"get" => ["1.0"], "hosts" => [{"host" => "localhost/161"}]},
           {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1"}]},

--- a/test/sample.conf
+++ b/test/sample.conf
@@ -2,7 +2,7 @@ input {
   snmp {
     get => ["1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0"]
     mib_paths => ["/Users/colin/dev/src/elasticsearch/logstash-plugins/logstash-input-snmp/test/RFC1213-MIB.dic"]
-    hosts => [{host => "udp:127.0.0.1/161" community => "public"}]
+    hosts => [{host => "tcp:127.0.0.1/1161" community => "public"}]
   }
   snmp {
     walk => ["1.3.6.1.2.1.1"]

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -7,7 +7,8 @@ require "logstash/inputs/snmp/mib"
 
 mib = LogStash::SnmpMib.new
 mib.add_mib_path(File.expand_path(File.join("..", "..", "spec", "fixtures", "RFC1213-MIB.dic"), __FILE__))
-client = LogStash::SnmpClient.new("udp:127.0.0.1/161", "public", "2c", 2, 1000, mib)
+#client = LogStash::SnmpClient.new("tcp", "127.0.0.1", "1161", "public", "2c", 2, 1000, mib)
+client = LogStash::SnmpClient.new("udp", "127.0.0.1", "161", "public", "2c", 2, 1000, mib)
 
 pp client.get("1.3.6.1.2.1.1.1.0")
 


### PR DESCRIPTION
Add support for tcp transport protocol.

I locally tested this both for udp and tcp and both are working. We are lacking test/spec coverage for this and I will followup with an initial spec for the client.
