### PR TITLE
add support for protocol version 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.1.0.beta3
   - add tcp transport protocol support, https://github.com/logstash-plugins/logstash-input-snmp/pull/8
+  - add SNMPv1 protocol version support, https://github.com/logstash-plugins/logstash-input-snmp/pull/9
 
 ## 0.1.0.beta2
   - add host info in metadata and host field, https://github.com/logstash-plugins/logstash-input-snmp/pull/7

--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -26,7 +26,7 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
   #  for example `host => "udp:127.0.0.1/161"`
   # Each host definition can optionally include the following keys and values:
   #  `community` with a default value of `public`
-  #  `version` with a default value of `2c`
+  #  `version` `1` or `2c` with a default value of `2c`
   #  `retries` with a detault value of `2`
   #  `timeout` in milliseconds with a default value of `1000`
   config :hosts, :validate => :array  #[ {"host" => "udp:127.0.0.1/161", "community" => "public"} ]
@@ -71,6 +71,8 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
       host_name = host["host"]
       community = host["community"] || "public"
       version = host["version"] || "2c"
+      raise(LogStash::ConfigurationError, "only protocol version '1' and '2c' are supported for host option '#{host_name}'") unless version =~ VERSION_REGEX
+
       retries = host["retries"] || 2
       timeout = host["timeout"] || 1000
 
@@ -146,6 +148,7 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
 
   OID_REGEX = /^\.?([0-9\.]+)$/
   HOST_REGEX = /^(?<host_protocol>udp|tcp):(?<host_address>.+)\/(?<host_port>\d+)$/i
+  VERSION_REGEX =/^1|2c$/
 
   def validate_oids!
     @get = Array(@get).map do |oid|

--- a/lib/logstash/inputs/snmp/client.rb
+++ b/lib/logstash/inputs/snmp/client.rb
@@ -136,8 +136,14 @@ module LogStash
     end
 
     def parse_version(version)
-      # TODO implement
-      SnmpConstants.version2c
+      case version.to_s
+      when "2c"
+        SnmpConstants.version2c
+      when "1"
+        SnmpConstants.version1
+      else
+        raise(SnmpClientError, "protocol version '#{version}' is not supported, expected versions are '1' and '2c'")
+      end
     end
   end
 end

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -56,6 +56,8 @@ describe LogStash::Inputs::Snmp do
           {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/161", "community" => "public"}]},
           {"get" => ["1.0"], "hosts" => [{"host" => "tcp:127.0.0.1/112345"}]},
           {"get" => ["1.0"], "hosts" => [{"host" => "tcp:127.0.0.1/161", "community" => "public"}]},
+          {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/161", "version" => "1"}]},
+          {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/161", "version" => "2c"}]},
       ]
     }
 
@@ -69,6 +71,8 @@ describe LogStash::Inputs::Snmp do
           {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/"}]},
           {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/aaa"}]},
           {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/161"}, {"host" => "udp:127.0.0.1/aaa"}]},
+          {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/161", "version" => "2"}]},
+          {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/161", "version" => "3"}]},
           {"get" => ["1.0"], "hosts" => ""},
           {"get" => ["1.0"], "hosts" => []},
           {"get" => ["1.0"] },


### PR DESCRIPTION
Add support for SNMP protocol v1. 
Tested manually on my local snmpd server. 
Will add proper client specs shortly.