### PR TITLE
add missing coercions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.0.beta4
+  - Fixed missing coercions [#12](https://github.com/logstash-plugins/logstash-input-snmp/pull/12)
+
 ## 0.1.0.beta3
   - add tcp transport protocol support, https://github.com/logstash-plugins/logstash-input-snmp/pull/8
   - add SNMPv1 protocol version support, https://github.com/logstash-plugins/logstash-input-snmp/pull/9

--- a/lib/logstash/inputs/snmp/client.rb
+++ b/lib/logstash/inputs/snmp/client.rb
@@ -104,13 +104,15 @@ module LogStash
 
     private
 
+    NULL_STRING = "null".freeze
+
     def coerce(variable)
       variable_syntax = variable.getSyntax
       # puts("variable.getSyntaxString=#{variable.getSyntaxString}")
       case variable_syntax
-      when BER::OCTETSTRING
+      when BER::OCTETSTRING, BER::BITSTRING
         variable.toString
-      when BER::TIMETICKS, BER::COUNTER, BER::COUNTER32
+      when BER::TIMETICKS, BER::COUNTER, BER::COUNTER32, BER::COUNTER64
         variable.toLong
       when BER::INTEGER, BER::INTEGER32, BER::GAUGE, BER::GAUGE32
         variable.toInt
@@ -118,6 +120,8 @@ module LogStash
         variable.toString
       when BER::OID
         variable.toString
+      when BER::NULL
+        NULL_STRING
       when BER::NOSUCHOBJECT
         "Error: No Such Instance currently exists at this OID"
       else

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '0.1.0.beta3'
+  s.version       = '0.1.0.beta4'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes #11 
This adds some missing coercions for `BITSTRING`, `COUNTER64` and `NULL`.
Tested manually locally, no spec coverage for this yet (working on it for larger `Client` class specs.