### PR TITLE
Add no_codec condition to the doc and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## Next
+## 1.0.1
+  - Added no_codec condition to the documentation and bumped version [#39](https://github.com/logstash-plugins/logstash-input-snmp/pull/39)
   - Changed docs to improve options layout [#38](https://github.com/logstash-plugins/logstash-input-snmp/pull/38)
 
 ## 1.0.0

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -24,6 +24,8 @@ include::{include_path}/plugin_header.asciidoc[]
 The SNMP input polls network devices using Simple Network Management Protocol (SNMP)
 to gather information related to the current state of the devices operation.
 
+The SNMP input plugin supports SNMP v1, v2c, and v3 over UDP and TCP transport protocols.
+
 [id="plugins-{type}s-{plugin}-import-mibs"]
 ==== Importing MIBs 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,8 +1,6 @@
 :plugin: snmp
 :type: input
-:default_codec: plain
-
-// TO DO:  VERIFY default codec!
+:no_codec:
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -318,4 +316,4 @@ input {
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:default_codec!:
+:no_codec!:

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '1.0.0'
+  s.version       = '1.0.1'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Added `no_codec` tag to doc and removed comment `//Verify default codec`
Included fix for #40 to add SNMP versions and protocols