### PR TITLE
Docs update for tables support, snmpv3 example, and typo fix

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -288,6 +288,25 @@ The `security_level` option specifies the SNMPv3 security level between Authenti
 * Value can be any of: `noAuthNoPriv`, `authNoPriv`, `authPriv`
 * There is no default value for this setting
 
+* Specifying SNMPv3 settings*
+
+[source,ruby]
+-----
+input {
+  snmp {
+    hosts => [{host => "udp:127.0.0.1/161" version => "3"}]
+    get => ["1.3.6.1.2.1.1.1.0"]
+    security_name => "mySecurityName"
+    auth_protocol => "sha"
+    auth_pass => "ShaPassword"
+    priv_protocol => "aes"
+    priv_pass => "AesPasword"
+    security_level => "authPriv"
+  }
+}
+
+-----
+
 ==== More configuration examples
 
 *Using both `get` and `walk` in the same poll cycle for each host(s)*

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -288,7 +288,7 @@ The `security_level` option specifies the SNMPv3 security level between Authenti
 * Value can be any of: `noAuthNoPriv`, `authNoPriv`, `authPriv`
 * There is no default value for this setting
 
-* Specifying SNMPv3 settings*
+*Specifying SNMPv3 settings*
 
 [source,ruby]
 -----

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -59,8 +59,9 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-hosts>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-mib_paths>> |<<path,path>>|No
-| <<plugins-{type}s-{plugin}-oid_root_skip>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-oid_root_skip>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-walk>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-tables>> |<<array,array>>|No
 |=======================================================================
 
 ==== SNMPv3 Authentication Options
@@ -193,6 +194,41 @@ Example
   snmp {
     walk => ["1.3.6.1.2.1.1"]
     hosts => [{host => "udp:127.0.0.1/161" community => "public"}]
+  }
+}
+-----
+
+[id="plugins-{type}s-{plugin}-tables"]
+===== `tables`
+
+The `tables` option is used to query for tabular values for the given column OID(s).
+
+Each table definition is a hash and must define the name key and value and the columns to return.
+
+* Value type is <<array,array>>
+* There is no default value for this setting
+* Results are returned under a field using the table name
+
+*Specifying a single table*
+
+[source,ruby]
+-----
+input {
+  snmp {
+    hosts => [{host => "udp:127.0.0.1/161" community => "public" version => "2c"  retries => 2  timeout => 1000}]
+    tables => [ {"name" => "interfaces" "columns" => ["1.3.6.1.2.1.2.2.1.1", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.5"]} ]
+  }
+}
+-----
+
+*Specifying multiple tables*
+
+[source,ruby]
+-----
+input {
+  snmp {
+    get => ["1.3.6.1.2.1.1.1.0"]
+    tables => [ {"name" => "interfaces" "columns" => ["1.3.6.1.2.1.2.2.1.1", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.5"]}, {"name" => "ltmPoolStatTable" "columns" => ["1.3.6.1.4.1.3375.2.2.5.2.3.1.1", "1.3.6.1.4.1.3375.2.2.5.2.3.1.6"]} ]
   }
 }
 -----


### PR DESCRIPTION
@colinsurprenant 

Quick docs update to add:
- tables information into the index.asciidoc #55 
- example of how to specify the SNMPv3 settings - #53 
- fixed up a typo in the oid_root_skip definition in the table #56 