### PR TITLE
Fixed GAUGE32 integer overflow in base_client.rb

### DIFF
--- a/lib/logstash/inputs/snmp/base_client.rb
+++ b/lib/logstash/inputs/snmp/base_client.rb
@@ -159,9 +159,9 @@ module LogStash
       case variable_syntax
         when BER::OCTETSTRING, BER::BITSTRING
           variable.toString
-        when BER::TIMETICKS, BER::COUNTER, BER::COUNTER32, BER::COUNTER64
+        when BER::TIMETICKS, BER::COUNTER, BER::COUNTER32, BER::COUNTER64, BER::GAUGE, BER::GAUGE32
           variable.toLong
-        when BER::INTEGER, BER::INTEGER32, BER::GAUGE, BER::GAUGE32
+        when BER::INTEGER, BER::INTEGER32
           variable.toInt
         when BER::IPADDRESS
           variable.toString

--- a/spec/inputs/snmp/base_client_spec.rb
+++ b/spec/inputs/snmp/base_client_spec.rb
@@ -36,7 +36,7 @@ module LogStash
         expect(subject.coerce(v)).to eq("error: unknown variable syntax 130, EndOfMibView")
       end
 	  
-	  it "should handle max unsigned 32 bits integer GAUGE32" do
+      it "should handle max unsigned 32 bits integer GAUGE32" do
         MAX_UNSIGNED_INT_32 = 4294967295
         v = Gauge32.new(MAX_UNSIGNED_INT_32)
         expect(subject.coerce(v)).to eq(MAX_UNSIGNED_INT_32)

--- a/spec/inputs/snmp/base_client_spec.rb
+++ b/spec/inputs/snmp/base_client_spec.rb
@@ -33,6 +33,18 @@ module LogStash
         expect(subject).to receive(:logger).exactly(1).times.and_call_original
         expect(subject.coerce(v)).to eq("error: unknown variable syntax 130, EndOfMibView")
       end
+	  
+	  it "should handle max unsigned 32 bits integer GAUGE32" do
+        MAX_UNSIGNED_INT_32 = 4294967295
+        v = Gauge32.new(MAX_UNSIGNED_INT_32)
+        expect(subject.coerce(v)).to eq(MAX_UNSIGNED_INT_32)
+      end
+
+      it "should handle max signed 32 bits integer INTEGER32" do
+        MAX_SIGNED_INT_32 = 2147483647
+        v = Integer32.new(MAX_SIGNED_INT_32)
+        expect(subject.coerce(v)).to eq(MAX_SIGNED_INT_32)
+      end
     end
   end
 end

--- a/spec/inputs/snmp/base_client_spec.rb
+++ b/spec/inputs/snmp/base_client_spec.rb
@@ -4,6 +4,8 @@ require "logstash/inputs/snmp/base_client"
 
 java_import "org.snmp4j.smi.AbstractVariable"
 java_import "org.snmp4j.smi.SMIConstants"
+java_import "org.snmp4j.smi.Gauge32"
+java_import "org.snmp4j.smi.Integer32"
 
 module LogStash
 


### PR DESCRIPTION
As discussed here:
https://github.com/logstash-plugins/logstash-input-snmp/issues/64

Best regards