### PR TITLE
support for snmpv3 engine ID

### DIFF
--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -94,6 +94,9 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
   # The SNMPv3 security level can be Authentication, No Privacy; Authentication, Privacy; or no Authentication, no Privacy
   config :security_level, :validate => ["noAuthNoPriv", "authNoPriv", "authPriv"]
 
+  # The SNMPv3 optional engine ID
+  config :engine_id, :validate => :string
+
   BASE_MIB_PATH = ::File.join(__FILE__, "..", "..", "..", "mibs")
   PROVIDED_MIB_PATHS = [::File.join(BASE_MIB_PATH, "logstash"), ::File.join(BASE_MIB_PATH, "ietf")].map { |path| ::File.expand_path(path) }
 
@@ -152,7 +155,7 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
         validate_v3_user! # don't really care if verified for every host
         auth_pass = @auth_pass.nil? ? nil : @auth_pass.value
         priv_pass = @priv_pass.nil? ? nil : @priv_pass.value
-        definition[:client] = LogStash::SnmpClientV3.new(protocol, address, port, retries, timeout, mib, @security_name, @auth_protocol, auth_pass, @priv_protocol, priv_pass, @security_level)
+        definition[:client] = LogStash::SnmpClientV3.new(protocol, address, port, retries, timeout, mib, @security_name, @auth_protocol, auth_pass, @priv_protocol, priv_pass, @security_level, @engine_id)
       else
         definition[:client] = LogStash::SnmpClient.new(protocol, address, port, community, version, retries, timeout, mib)
       end

--- a/lib/logstash/inputs/snmp/clientv3.rb
+++ b/lib/logstash/inputs/snmp/clientv3.rb
@@ -39,7 +39,7 @@ java_import 'org.snmp4j.util.DefaultPDUFactory'
 module LogStash
   class SnmpClientV3 < BaseSnmpClient
 
-    def initialize(protocol, address, port, retries, timeout, mib, security_name, auth_protocol, auth_pass, priv_protocol, priv_pass, security_level)
+    def initialize(protocol, address, port, retries, timeout, mib, security_name, auth_protocol, auth_pass, priv_protocol, priv_pass, security_level, engine_id)
       super(protocol, address, port, retries, timeout, mib)
 
       security_level = parse_security_level(security_level)
@@ -48,8 +48,9 @@ module LogStash
       priv_protocol = parse_priv_protocol(priv_protocol)
       auth_pass = auth_pass.nil? ? nil : OctetString.new(auth_pass)
       priv_pass = priv_pass.nil? ? nil : OctetString.new(priv_pass)
+      engine_id = OctetString.new(engine_id.nil? ? MPv3.createLocalEngineID : engine_id)
 
-      usm = USM.new(SecurityProtocols.getInstance, OctetString.new(MPv3.createLocalEngineID), 0)
+      usm = USM.new(SecurityProtocols.getInstance, engine_id, 0)
       SecurityModels.getInstance.addSecurityModel(usm)
 
       @snmp.getUSM.addUser(UsmUser.new(security_name, auth_protocol, auth_pass, priv_protocol, priv_pass))

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -102,7 +102,8 @@ describe LogStash::Inputs::Snmp do
     let(:valid_configs) {
       [
 	  {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/161", "version" => "3"}], "security_name" => "ciscov3", "auth_protocol" => "sha", "auth_pass" => "myshapass", "priv_protocol" => "aes", "priv_pass" => "myprivpass", "security_level" => "authNoPriv"},
-	  {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/161", "version" => "3"}], "security_name" => "dellv3", "auth_protocol" => "md5", "auth_pass" => "myshapass", "priv_protocol" => "3des", "priv_pass" => "myprivpass", "security_level" => "authNoPriv"}
+	  {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/161", "version" => "3"}], "security_name" => "dellv3", "auth_protocol" => "md5", "auth_pass" => "myshapass", "priv_protocol" => "3des", "priv_pass" => "myprivpass", "security_level" => "authNoPriv"},
+    {"get" => ["1.0"], "hosts" => [{"host" => "udp:127.0.0.1/161", "version" => "3"}], "security_name" => "dellv3", "auth_protocol" => "md5", "auth_pass" => "myshapass", "priv_protocol" => "3des", "priv_pass" => "myprivpass", "security_level" => "authNoPriv", "engine_id" => "some engine"}
       ]
     }
 


### PR DESCRIPTION
Fixes logstash-plugins/logstash-integration-snmp#41 

adds support for SNMPv3 Engine ID. 