### PR TITLE
fix multithreading problem when using multiple snmp inputs with multiple v3 credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.3
+  -  Fixed: multithreading problem when using multiple snmp inputs with multiple v3 credentials [#80](https://github.com/logstash-plugins/logstash-input-snmp/pull/80)
+
 ## 1.2.2
   -  Refactor: scope and review java_imports [#72](https://github.com/logstash-plugins/logstash-input-snmp/pull/72)
 

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '1.2.2'
+  s.version       = '1.2.3'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
When using multiple snmp inputs within a single pipeline or in multiple pipelines could result in decoding problems and in particular when using SNMPv3 the following error could occur when using different v3 credentials across the snmp inputs:

```
org.snmp4j.MessageException: Message processing model 3 returned error: Unknown security name
```

This PR fixes the problem by using singleton factories to produce a single udp or tcp `Snmp` object that is listened on and for v3 clients, a single `USM` for all threads.

I was first able to reproduce the problem locally using a local `snmpd` server using 2 different SNMPv3 users and configuring 2 pipelines polling the same server but with a different user. 

I successfully tested the this fix in the following scenarios:
- single pipeline, single snmp input, multiple udp hosts
- single pipeline, single snmp input, mix of udp and tcp hosts
- single pipeline, multiple snmp inputs, mix of udp and tcp hosts
- multiple pipelines, multiple snmp inputs, mix of udp and tcp hosts