### PR TITLE
Support SNMPv3 multiple identical security name with different credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.4
+  -  Fixed: support SNMPv3 multiple identical security name with different credentials [#84](https://github.com/logstash-plugins/logstash-input-snmp/pull/84)
+
 ## 1.2.3
   -  Fixed: multithreading problem when using multiple snmp inputs with multiple v3 credentials [#80](https://github.com/logstash-plugins/logstash-input-snmp/pull/80)
 

--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -212,7 +212,14 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
     end
   end
 
-  def stop
+  def close
+    @client_definitions.each do |definition|
+      begin
+        definition[:client].close
+      rescue => e
+        logger.warn("error closing client on #{definition[:host_address]}, ignoring", :exception => e)
+      end
+    end
   end
 
   private

--- a/lib/logstash/inputs/snmp/client.rb
+++ b/lib/logstash/inputs/snmp/client.rb
@@ -18,6 +18,10 @@ module LogStash
     def initialize(protocol, address, port, community, version, retries, timeout, mib)
       super(protocol, address, port, retries, timeout, mib)
       raise(SnmpClientError, "SnmpClient is expecting verison '1' or '2c'") unless ["1", "2c"].include?(version.to_s)
+
+      @snmp = Snmp.new(create_transport(protocol))
+      @snmp.listen
+
       @target = build_target("#{protocol}:#{address}/#{port}", community, version, retries, timeout)
     end
 

--- a/lib/logstash/inputs/snmp/client.rb
+++ b/lib/logstash/inputs/snmp/client.rb
@@ -25,6 +25,10 @@ module LogStash
       @target = build_target("#{protocol}:#{address}/#{port}", community, version, retries, timeout)
     end
 
+    def close
+      @snmp.close
+    end
+
     private
 
     def get_pdu

--- a/lib/logstash/inputs/snmp/clientv3.rb
+++ b/lib/logstash/inputs/snmp/clientv3.rb
@@ -64,6 +64,10 @@ module LogStash
       @target = build_target("#{protocol}:#{address}/#{port}", security_name, security_level, retries, timeout)
     end
 
+    def close
+      @snmp.close
+    end
+
     private
 
     def build_target(address, name, seclevel, retries, timeout)

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '1.2.3'
+  s.version       = '1.2.4'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -15,6 +15,8 @@ describe LogStash::Inputs::Snmp do
     before do
       expect(LogStash::SnmpClient).to receive(:new).and_return(mock_client)
       expect(mock_client).to receive(:get).and_return({})
+      # devutils in v6 calls close on the test pipelines while it does not in v7+
+      expect(mock_client).to receive(:close).at_most(:once)
     end
   end
 
@@ -128,6 +130,8 @@ describe LogStash::Inputs::Snmp do
     before do
       expect(LogStash::SnmpClient).to receive(:new).and_return(mock_client)
       expect(mock_client).to receive(:get).and_return({"foo" => "bar"})
+      # devutils in v6 calls close on the test pipelines while it does not in v7+
+      expect(mock_client).to receive(:close).at_most(:once)
     end
 
     it "shoud add @metadata fields and add default host field" do


### PR DESCRIPTION
Fixes #82 

This Fixes the issue when polling with SNMPv3 of different hosts using  multiple inputs (within a pipeline or in multiple pipelines) where the same security name is used but with different credentials on the different hosts.

This is actually a partial revert of  #80 and the proper fix for it by also getting rid of the singleton objects so that individual plugin instances can correctly close its own `Snmp` object when reloading pipelines for example.

The scenarios described in #80 were manually tested and also this specific problem of SNMPv3 multiple identical security name with different credentials. 