### PR TITLE
add integration tests

### DIFF
--- a/.ci/Dockerfile.snmp
+++ b/.ci/Dockerfile.snmp
@@ -3,12 +3,11 @@ FROM ubuntu:20.04
 ARG PORT
 
 RUN mkdir -p /share && apt-get update && apt-get -y install snmpd snmp libsnmp-dev
-#RUN apt-get -y install vim net-tools
 
 COPY snmpd.conf /etc/snmp/
 RUN sed -ie "s/:161/:$PORT/g" /etc/snmp/snmpd.conf && \
-    net-snmp-create-v3-user -ro -A STrP@SSPhr@sE -a SHA -X STr0ngP@SSWRD -x AES user_1 && \
-    net-snmp-create-v3-user -ro -A AWeP@SSPhr@sE -a SHA -X AWeS0meP@SSWRD -x AES user_2
+    net-snmp-create-v3-user -ro -A STrP@SSPhr@sE -a SHA -X STr0ngP@SSWRD$PORT -x AES user_1  && \
+    net-snmp-create-v3-user -ro -A AWeP@SSPhr@sE -a SHA -X AWeS0meP@SSWRD$PORT -x AES user_2
 
 EXPOSE $PORT $PORT/udp
 

--- a/.ci/Dockerfile.snmp
+++ b/.ci/Dockerfile.snmp
@@ -1,0 +1,15 @@
+FROM ubuntu:20.04
+
+ARG PORT
+
+RUN mkdir -p /share && apt-get update && apt-get -y install snmpd snmp libsnmp-dev
+#RUN apt-get -y install vim net-tools
+
+COPY snmpd.conf /etc/snmp/
+RUN sed -ie "s/:161/:$PORT/g" /etc/snmp/snmpd.conf && \
+    net-snmp-create-v3-user -ro -A STrP@SSPhr@sE -a SHA -X STr0ngP@SSWRD -x AES user_1 && \
+    net-snmp-create-v3-user -ro -A AWeP@SSPhr@sE -a SHA -X AWeS0meP@SSWRD -x AES user_2
+
+EXPOSE $PORT $PORT/udp
+
+ENTRYPOINT ["snmpd", "-f", "-L"]

--- a/.ci/docker-compose.override.yml
+++ b/.ci/docker-compose.override.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  logstash:
+    command: /usr/share/plugins/plugin/.ci/logstash-run.sh
+    environment:
+      - ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
+    depends_on:
+      - snmp1
+      - snmp2
+  snmp1:
+    hostname: snmp1
+    container_name: snmp1
+    ports:
+      - "161:161/tcp"
+      - "161:161/udp"
+    build:
+      context: .
+      dockerfile: Dockerfile.snmp
+      args:
+        - PORT=161
+  snmp2:
+    hostname: snmp2
+    container_name: snmp2
+    ports:
+      - "162:162/tcp"
+      - "162:162/udp"
+    build:
+      context: .
+      dockerfile: Dockerfile.snmp
+      args:
+        - PORT=162

--- a/.ci/docker-compose.override.yml
+++ b/.ci/docker-compose.override.yml
@@ -1,19 +1,28 @@
-version: '3'
+version: '2.4'
 
 services:
   logstash:
+    container_name: snmp_ls
     command: /usr/share/plugins/plugin/.ci/logstash-run.sh
     environment:
       - ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
     depends_on:
       - snmp1
       - snmp2
+    networks:
+      app_net:
+        ipv4_address: 172.16.238.10
+        ipv6_address: 2001:3984:3989::10
   snmp1:
     hostname: snmp1
     container_name: snmp1
     ports:
       - "161:161/tcp"
       - "161:161/udp"
+    networks:
+      app_net:
+        ipv4_address: 172.16.238.161
+        ipv6_address: 2001:3984:3989::161
     build:
       context: .
       dockerfile: Dockerfile.snmp
@@ -25,8 +34,24 @@ services:
     ports:
       - "162:162/tcp"
       - "162:162/udp"
+    networks:
+      app_net:
+        ipv4_address: 172.16.238.162
+        ipv6_address: 2001:3984:3989::162
     build:
       context: .
       dockerfile: Dockerfile.snmp
       args:
         - PORT=162
+
+networks:
+  app_net:
+    driver: bridge
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.238.0/24
+          gateway: 172.16.238.1
+        - subnet: 2001:3984:3989::/64
+          gateway: 2001:3984:3989::1

--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -1,0 +1,21 @@
+# docker ipv6 only support in version 2.x
+version: '2.4'
+
+# run tests:  cd ci/unit; docker-compose up --build --force-recreate
+# manual:  cd ci/unit; docker-compose run logstash bash
+services:
+
+  logstash:
+    build:
+      context: ../
+      dockerfile: .ci/Dockerfile
+      args:
+        - ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
+        - DISTRIBUTION=${DISTRIBUTION:-default}
+        #- INTEGRATION=false
+    command: .ci/run.sh
+    env_file: docker.env
+    environment:
+      - SPEC_OPTS
+      #- JRUBY_OPTS
+    tty: true

--- a/.ci/logstash-run.sh
+++ b/.ci/logstash-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+
+bundle exec rspec spec && bundle exec rspec --tag integration -fd 2>/dev/null

--- a/.ci/snmpd.conf
+++ b/.ci/snmpd.conf
@@ -1,0 +1,88 @@
+###########################################################################
+#
+# snmpd.conf
+# An example configuration file for configuring the Net-SNMP agent ('snmpd')
+# See snmpd.conf(5) man page for details
+#
+###########################################################################
+# SECTION: System Information Setup
+#
+
+# syslocation: The [typically physical] location of the system.
+#   Note that setting this value here means that when trying to
+#   perform an snmp SET operation to the sysLocation.0 variable will make
+#   the agent return the "notWritable" error code.  IE, including
+#   this token in the snmpd.conf file will disable write access to
+#   the variable.
+#   arguments:  location_string
+sysLocation    Sitting on the Dock of the Bay
+sysContact     Me <me@example.org>
+
+# sysservices: The proper value for the sysServices object.
+#   arguments:  sysservices_number
+sysServices    72
+
+
+
+###########################################################################
+# SECTION: Agent Operating Mode
+#
+#   This section defines how the agent will operate when it
+#   is running.
+
+# master: Should the agent operate as a master agent or not.
+#   Currently, the only supported master agent type for this token
+#   is "agentx".
+#
+#   arguments: (on|yes|agentx|all|off|no)
+
+master  agentx
+
+# agentaddress: The IP address and port number that the agent will listen on.
+#   By default the agent listens to any and all traffic from any
+#   interface on the default SNMP port (161).  This allows you to
+#   specify which address, interface, transport type and port(s) that you
+#   want the agent to listen on.  Multiple definitions of this token
+#   are concatenated together (using ':'s).
+#   arguments: [transport:]port[@interface/address],...
+
+#agentaddress  127.0.0.1,[::1]
+agentaddress  udp:161,tcp:161,udp6:161,tcp6:161
+
+
+
+###########################################################################
+# SECTION: Access Control Setup
+#
+#   This section defines who is allowed to talk to your running
+#   snmp agent.
+
+# Views
+#   arguments viewname included [oid]
+
+#  system + hrSystem groups only
+view   systemonly  included   .1.3.6.1.2.1.1
+view   systemonly  included   .1.3.6.1.2.1.25.1
+
+
+# rocommunity: a SNMPv1/SNMPv2c read-only access community name
+#   arguments:  community [default|hostname|network/bits] [oid | -V view]
+
+# Read-only access to everyone to the systemonly view
+rocommunity  public default -V systemonly
+rocommunity6 public default -V systemonly
+
+# SNMPv3 doesn't use communities, but users with (optionally) an
+# authentication and encryption string. This user needs to be created
+# with what they can view with rouser/rwuser lines in this file.
+#
+# createUser username (MD5|SHA|SHA-512|SHA-384|SHA-256|SHA-224) authpassphrase [DES|AES] [privpassphrase]
+# e.g.
+# createuser authPrivUser SHA-512 myauthphrase AES myprivphrase
+#
+# This should be put into /var/lib/snmp/snmpd.conf
+#
+# rouser: a SNMPv3 read-only access username
+#    arguments: username [noauth|auth|priv [OID | -V VIEW [CONTEXT]]]
+rouser authPrivUser authpriv -V systemonly
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.2.7
-  -  Added integration tests to ensure SNMP server and IPv6 connections [#87](https://github.com/logstash-plugins/logstash-input-snmp/pull/87)
+  - Added integration tests to ensure SNMP server and IPv6 connections [#87](https://github.com/logstash-plugins/logstash-input-snmp/pull/87)
 
 ## 1.2.6
   - Docs: example on setting IPv6 hosts [#89](https://github.com/logstash-plugins/logstash-input-snmp/pull/89)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.6
+  -  Added integration tests to ensure SNMP server and IPv6 connections [#87](https://github.com/logstash-plugins/logstash-input-snmp/pull/87)
+
 ## 1.2.5
   -  Updated snmp4j library to v2.8.4 [#86](https://github.com/logstash-plugins/logstash-input-snmp/pull/86)
 

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '1.2.6'
+  s.version       = '1.2.7'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '1.2.5'
+  s.version       = '1.2.6'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/integration/it_spec.rb
+++ b/spec/inputs/integration/it_spec.rb
@@ -43,12 +43,12 @@ describe LogStash::Inputs::Snmp do
     end
   end
 
-  describe "against snmp server", :integration => true do
+  describe "against single snmp server with snmpv2 and udp", :integration => true do
     let(:config) { super.merge({"hosts" => [{"host" => "udp:snmp1/161", "community" => "public"}]})}
     it_behaves_like "snmp plugin return single event"
   end
 
-  describe "against snmpv3 server", :integration => true do
+  describe "against single server with snmpv3 and tcp", :integration => true do
     let(:config) { super.merge({
        "hosts" => [{"host" => "tcp:snmp1/161", "version" => "3"}],
        "security_name" => "user_1",
@@ -83,7 +83,7 @@ describe LogStash::Inputs::Snmp do
     end
   end
 
-  describe "single plugin input and mix of udp tcp", :integration => true do
+  describe "single input plugin on single server with snmpv2 and mix of udp and tcp", :integration => true do
     let(:config) { super.merge({"hosts" => [{"host" => "udp:snmp1/161", "community" => "public"}, {"host" => "tcp:snmp1/161", "community" => "public"}]})}
     it "should return two events " do
       plugin.register
@@ -92,13 +92,13 @@ describe LogStash::Inputs::Snmp do
       plugin.run(queue)
       plugin.close
 
-      host_cnt_snmp1 = queue.reduce(0) { |sum, event| sum + (event.get("host") == "snmp1"? 1: 0) }
+      host_cnt_snmp1 = queue.select {|event| event.get("host") == "snmp1"}.size
       expect(queue.size).to eq(2)
       expect(host_cnt_snmp1).to eq(2)
     end
   end
 
-  describe "single plugin input and multiple udp hosts", :integration => true do
+  describe "single input plugin on multiple udp hosts", :integration => true do
     let(:config) { super.merge({"hosts" => [{"host" => "udp:snmp1/161", "community" => "public"}, {"host" => "udp:snmp2/162", "community" => "public"}]})}
     it "should return two events, one per host" do
       plugin.register
@@ -159,7 +159,7 @@ describe LogStash::Inputs::Snmp do
     it_behaves_like "snmp plugin return one udp event and one tcp event", config
   end
 
-  describe "same security name with different credentials and mix of udp tcp hosts", :integration => true do
+  describe "two plugins on different hosts with snmpv3 with same security name with different credentials and mix of udp and tcp", :integration => true do
     config = <<-CONFIG
         input {
           snmp {
@@ -188,7 +188,7 @@ describe LogStash::Inputs::Snmp do
     it_behaves_like "snmp plugin return one udp event and one tcp event", config
   end
 
-  describe "ipv6 against snmp1 server", :integration => true do
+  describe "single host with tcp over ipv6", :integration => true do
     let(:config) { super.merge({"hosts" => [{"host" => "tcp:[2001:3984:3989::161]/161"}]})}
     it_behaves_like "snmp plugin return single event"
   end

--- a/spec/inputs/integration/it_spec.rb
+++ b/spec/inputs/integration/it_spec.rb
@@ -1,0 +1,74 @@
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/inputs/snmp"
+
+describe LogStash::Inputs::Snmp, :integration => true do
+  let(:config) { {"get" => ["1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0"]} }
+  let(:plugin) { LogStash::Inputs::Snmp.new(config)}
+
+  after(:each) do
+    plugin.stop
+  end
+
+  shared_examples "snmp plugin return single event" do
+    it "should has OID value" do
+      plugin.register
+      queue = []
+      stop_plugin_after_seconds(plugin)
+      plugin.run(queue)
+      event = queue.pop
+
+      expect(event).to be_a(LogStash::Event)
+      expect(event.get("iso.org.dod.internet.mgmt.mib-2.system.sysUpTime.sysUpTimeInstance")).to be_a Integer
+      expect(event.get("iso.org.dod.internet.mgmt.mib-2.system.sysName.0")).to be_a String
+      expect(event.get("iso.org.dod.internet.mgmt.mib-2.system.sysDescr.0")).to be_a String
+    end
+  end
+
+  shared_examples "snmp plugin return events" do
+    it "should has two events" do
+      plugin.register
+      queue = []
+      stop_plugin_after_seconds(plugin)
+      plugin.run(queue)
+
+      expect(queue.size).to eq(2)
+    end
+  end
+
+  describe "against snmp server" do
+    let(:config) { super.merge({"hosts" => [{"host" => "udp:snmp1/161", "community" => "public"}]})}
+    it_behaves_like "snmp plugin return single event"
+  end
+
+  describe "against snmpv3 server" do
+    let(:config) { super.merge({
+       "hosts" => [{"host" => "tcp:snmp1/161", "version" => "3"}],
+       "security_name" => "user_1",
+       "auth_protocol" => "sha",
+       "auth_pass" => "STrP@SSPhr@sE",
+       "priv_protocol" => "aes",
+       "priv_pass" => "STr0ngP@SSWRD",
+       "security_level" => "authPriv"
+                               })}
+
+    it_behaves_like "snmp plugin return single event"
+  end
+
+  describe "single plugin input and mix of udp tcp" do
+    let(:config) { super.merge({"hosts" => [{"host" => "udp:snmp1/161", "community" => "public"}, {"host" => "tcp:snmp1/161", "community" => "public"}]})}
+    it_behaves_like "snmp plugin return events"
+  end
+
+  describe "single plugin input and multiple udp hosts" do
+    let(:config) { super.merge({"hosts" => [{"host" => "udp:snmp1/161", "community" => "public"}, {"host" => "udp:snmp2/162", "community" => "public"}]})}
+    it_behaves_like "snmp plugin return events"
+  end
+
+
+  def stop_plugin_after_seconds(plugin)
+      Thread.new{
+        sleep(2)
+        plugin.do_stop
+      }
+  end
+end

--- a/spec/inputs/integration/it_spec.rb
+++ b/spec/inputs/integration/it_spec.rb
@@ -123,21 +123,21 @@ describe LogStash::Inputs::Snmp do
       plugin.register
       plugin2.register
       queue = []
+      queue2 = []
       t = Thread.new {
         stop_plugin_after_seconds(plugin)
         plugin.run(queue)
       }
       t2 = Thread.new {
         stop_plugin_after_seconds(plugin2)
-        plugin2.run(queue)
+        plugin2.run(queue2)
       }
       t.join(2100)
       t2.join(2100)
       plugin.close
       plugin2.close
 
-      hosts = queue.map { |event| event.get("host") }.sort
-      expect(queue.size).to eq(2)
+      hosts = [queue.pop, queue2.pop].map { |event| event.get("host") }.sort
       expect(hosts).to eq(["snmp1", "snmp2"])
     end
   end

--- a/spec/inputs/integration/it_spec.rb
+++ b/spec/inputs/integration/it_spec.rb
@@ -1,7 +1,7 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/snmp"
 
-describe LogStash::Inputs::Snmp, :integration => true do
+describe LogStash::Inputs::Snmp do
   let(:config) { {"get" => ["1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0"]} }
   let(:plugin) { LogStash::Inputs::Snmp.new(config)}
 
@@ -24,44 +24,55 @@ describe LogStash::Inputs::Snmp, :integration => true do
     end
   end
 
-  shared_examples "snmp plugin return events" do
-    it "should has two events" do
-      plugin.register
-      queue = []
-      stop_plugin_after_seconds(plugin)
-      plugin.run(queue)
-
-      expect(queue.size).to eq(2)
+  shared_examples "snmp plugin return one udp event and one tcp event" do |config|
+    it "should has one udp from snmp1 and one tcp from snmp2" do
+      events = input(config) { |_, queue| 2.times.collect { queue.pop } }
+      udp = 0; tcp = 0
+      events.each { |event|
+        if event.get("[@metadata][host_protocol]") == "udp"
+          udp += 1
+          expect(event.get("[@metadata][host_protocol]")).to eq("udp")
+          expect(event.get("[@metadata][host_address]")).to eq("snmp1")
+          expect(event.get("[@metadata][host_port]")).to eq("161")
+        else
+          tcp += 1
+          expect(event.get("[@metadata][host_protocol]")).to eq("tcp")
+          expect(event.get("[@metadata][host_address]")).to eq("snmp2")
+          expect(event.get("[@metadata][host_port]")).to eq("162")
+        end
+      }
+      expect(udp).to eq(1)
+      expect(tcp).to eq(1)
     end
   end
 
-  describe "against snmp server" do
+  describe "against snmp server", :integration => true do
     let(:config) { super.merge({"hosts" => [{"host" => "udp:snmp1/161", "community" => "public"}]})}
     it_behaves_like "snmp plugin return single event"
   end
 
-  describe "against snmpv3 server" do
+  describe "against snmpv3 server", :integration => true do
     let(:config) { super.merge({
        "hosts" => [{"host" => "tcp:snmp1/161", "version" => "3"}],
        "security_name" => "user_1",
        "auth_protocol" => "sha",
        "auth_pass" => "STrP@SSPhr@sE",
        "priv_protocol" => "aes",
-       "priv_pass" => "STr0ngP@SSWRD",
+       "priv_pass" => "STr0ngP@SSWRD161",
        "security_level" => "authPriv"
                                })}
 
     it_behaves_like "snmp plugin return single event"
   end
 
-  describe "invalid user against snmpv3 server" do
+  describe "invalid user against snmpv3 server", :integration => true do
     let(:config) { super.merge({
                                    "hosts" => [{"host" => "tcp:snmp1/161", "version" => "3"}],
                                    "security_name" => "user_2",
                                    "auth_protocol" => "sha",
                                    "auth_pass" => "STrP@SSPhr@sE",
                                    "priv_protocol" => "aes",
-                                   "priv_pass" => "STr0ngP@SSWRD",
+                                   "priv_pass" => "STr0ngP@SSWRD161",
                                    "security_level" => "authPriv"
                                })}
 
@@ -74,47 +85,111 @@ describe LogStash::Inputs::Snmp, :integration => true do
     end
   end
 
-  describe "single plugin input and mix of udp tcp" do
+  describe "single plugin input and mix of udp tcp", :integration => true do
     let(:config) { super.merge({"hosts" => [{"host" => "udp:snmp1/161", "community" => "public"}, {"host" => "tcp:snmp1/161", "community" => "public"}]})}
-    it_behaves_like "snmp plugin return events"
-  end
+    it "should return two events " do
+      plugin.register
+      queue = []
+      stop_plugin_after_seconds(plugin)
+      plugin.run(queue)
 
-  describe "single plugin input and multiple udp hosts" do
-    let(:config) { super.merge({"hosts" => [{"host" => "udp:snmp1/161", "community" => "public"}, {"host" => "udp:snmp2/162", "community" => "public"}]})}
-    it_behaves_like "snmp plugin return events"
-  end
-
-  describe "multiple plugin inputs and mix of udp tcp hosts" do
-    it "should has one event from udp and one event from tcp" do
-      config = <<-CONFIG
-          input {
-            snmp {
-              get => ["1.3.6.1.2.1.1.1.0"]
-              hosts => [{host => "udp:snmp1/161" community => "public"}]
-            }
-            snmp {
-              get => ["1.3.6.1.2.1.1.1.0"]
-              hosts => [{host => "tcp:snmp2/162" community => "public"}]
-            }
-          }
-      CONFIG
-      queue = input(config) { |_, queue| queue }
-
-      events = [queue.pop, queue.pop]
-      events.each { |event|
-        if event.get("[@metadata][host_protocol]") == "udp"
-          expect(event.get("[@metadata][host_protocol]")).to eq("udp")
-          expect(event.get("[@metadata][host_address]")).to eq("snmp1")
-          expect(event.get("[@metadata][host_port]")).to eq("161")
-          expect(event.get("[@metadata][host_community]")).to eq("public")
-        else
-          expect(event.get("[@metadata][host_protocol]")).to eq("tcp")
-          expect(event.get("[@metadata][host_address]")).to eq("snmp2")
-          expect(event.get("[@metadata][host_port]")).to eq("162")
-          expect(event.get("[@metadata][host_community]")).to eq("public")
-        end
-      }
+      host_cnt_snmp1 = queue.reduce(0) { |sum, event| sum + (event.get("host") == "snmp1"? 1: 0) }
+      expect(queue.size).to eq(2)
+      expect(host_cnt_snmp1).to eq(2)
     end
+  end
+
+  describe "single plugin input and multiple udp hosts", :integration => true do
+    let(:config) { super.merge({"hosts" => [{"host" => "udp:snmp1/161", "community" => "public"}, {"host" => "udp:snmp2/162", "community" => "public"}]})}
+    it "should return two events, one per host" do
+      plugin.register
+      queue = []
+      stop_plugin_after_seconds(plugin)
+      plugin.run(queue)
+
+      hosts = queue.map { |event| event.get("host") }.sort
+      expect(queue.size).to eq(2)
+      expect(hosts).to eq(["snmp1", "snmp2"])
+    end
+  end
+
+  describe "multiple pipelines and mix of udp tcp hosts", :integration => true do
+    let(:config) { {"get" => ["1.3.6.1.2.1.1.1.0"], "hosts" => [{"host" => "udp:snmp1/161", "community" => "public"}]} }
+    let(:config2) { {"get" => ["1.3.6.1.2.1.1.1.0"], "hosts" => [{"host" => "tcp:snmp2/162", "community" => "public"}]} }
+    let(:plugin) { LogStash::Inputs::Snmp.new(config)}
+    let(:plugin2) { LogStash::Inputs::Snmp.new(config2)}
+
+    it "should return two events, one per host" do
+      plugin.register
+      plugin2.register
+      queue = []
+      t = Thread.new {
+        stop_plugin_after_seconds(plugin)
+        plugin.run(queue)
+      }
+      t2 = Thread.new {
+        stop_plugin_after_seconds(plugin2)
+        plugin2.run(queue)
+      }
+      t.join(2100)
+      t2.join(2100)
+      plugin2.close
+
+      hosts = queue.map { |event| event.get("host") }.sort
+      expect(queue.size).to eq(2)
+      expect(hosts).to eq(["snmp1", "snmp2"])
+    end
+  end
+
+  describe "multiple plugin inputs and mix of udp tcp hosts", :integration => true do
+    config = <<-CONFIG
+        input {
+          snmp {
+            get => ["1.3.6.1.2.1.1.1.0"]
+            hosts => [{host => "udp:snmp1/161" community => "public"}]
+          }
+          snmp {
+            get => ["1.3.6.1.2.1.1.1.0"]
+            hosts => [{host => "tcp:snmp2/162" community => "public"}]
+          }
+        }
+    CONFIG
+
+    it_behaves_like "snmp plugin return one udp event and one tcp event", config
+  end
+
+  describe "same security name with different credentials and mix of udp tcp hosts", :integration => true do
+    config = <<-CONFIG
+        input {
+          snmp {
+            get => ["1.3.6.1.2.1.1.1.0"]
+            hosts => [{host => "udp:snmp1/161" version => "3"}]
+            security_name => "user_1"
+            auth_protocol => "sha"
+            auth_pass => "STrP@SSPhr@sE"
+            priv_protocol => "aes"
+            priv_pass => "STr0ngP@SSWRD161"
+            security_level => "authPriv"
+          }
+          snmp {
+            get => ["1.3.6.1.2.1.1.1.0"]
+            hosts => [{host => "tcp:snmp2/162" version => "3"}]
+            security_name => "user_1"
+            auth_protocol => "sha"
+            auth_pass => "STrP@SSPhr@sE"
+            priv_protocol => "aes"
+            priv_pass => "STr0ngP@SSWRD162"
+            security_level => "authPriv"
+          }
+        }
+    CONFIG
+
+    it_behaves_like "snmp plugin return one udp event and one tcp event", config
+  end
+
+  describe "ipv6 against snmp1 server", :integration => true do
+    let(:config) { super.merge({"hosts" => [{"host" => "tcp:[2001:3984:3989::161]/161"}]})}
+    it_behaves_like "snmp plugin return single event"
   end
 
   def stop_plugin_after_seconds(plugin)
@@ -123,4 +198,5 @@ describe LogStash::Inputs::Snmp, :integration => true do
         plugin.do_stop
       }
   end
+
 end


### PR DESCRIPTION
The PR does integration tests against two SNMP dockers with ipv6 to simulate the scenarios below.
- mix udp tcp
- multiple hosts
- snmpv3 connection
- invalid user
- multiple inputs with mix tcp udp hosts
- same security name mix of udp tcp hosts
- ipv6 connection