### PR TITLE
Feat: ECS compliance + optional target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## Unreleased
-  - Fix: update to Gradle 7 [#102](https://github.com/logstash-plugins/logstash-input-snmp/pull/102)
+## 1.3.0
+  - Feat: ECS compliance + optional target [#99](https://github.com/logstash-plugins/logstash-input-snmp/pull/99)
+  - Internal: update to Gradle 7 [#102](https://github.com/logstash-plugins/logstash-input-snmp/pull/102)
 
 ## 1.2.8
   - Fixed interval handling to only sleep off the _remainder_ of the interval (if any), and to log a helpful warning when crawling the hosts takes longer than the configured interval [#100](https://github.com/logstash-plugins/logstash-input-snmp/pull/100). Fixes [#61](https://github.com/logstash-plugins/logstash-input-snmp/issues/61).

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -354,7 +354,7 @@ Authentication, No Privacy; Authentication, Privacy; or no Authentication, no Pr
 The name of the field under which SNMP payloads are assigned.
 If not specified data will be stored in the root of the event.
 
-Setting a target is recommended when <<plugins-{type}s-{plugin}-ecs_compatibility>> enabled.
+Setting a target is recommended when <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled.
 
 ==== Configuration examples
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -39,7 +39,7 @@ Metadata fields follow a specific naming convention when <<plugins-{type}s-{plug
 |[@metadata][host_address]     |[@metadata][input][snmp][host][address]     |The host IP e.g. "192.168.1.1"
 |[@metadata][host_port]        |[@metadata][input][snmp][host][port]        |The host's port e.g. "161"
 |[@metadata][host_community]   |[@metadata][input][snmp][host][community]   |The configured community e.g. "public"
-|[host]                        |N/A                                         |Same as `[@metadata][host_address]`, no longer set in ECS mode
+|[host]                        |[host][ip]                                  |Same as `[@metadata][host_address]`, host's IP address
 |=======================================================================
 
 [id="plugins-{type}s-{plugin}-import-mibs"]
@@ -305,7 +305,7 @@ The `auth_protocol` option specifies the SNMPv3 authentication protocol or type
   * Value type is <<string,string>>
   * Supported values are:
     ** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
-    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, JMS specific properties)
+    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, the `host` field)
   * Default value depends on which version of Logstash is running:
     ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
     ** Otherwise, the default value is `disabled`.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,6 +26,21 @@ to gather information related to the current state of the devices operation.
 
 The SNMP input plugin supports SNMP v1, v2c, and v3 over UDP and TCP transport protocols.
 
+==== Compatibility with the Elastic Common Schema (ECS)
+
+Since SNMP data has specific field names, based on OIDs, we recommend setting a <<plugins-{type}s-{plugin}-target>>.
+Meta-data fields started following a naming convention when <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> in enabled.
+
+[cols="<l,<l,e,<e"]
+|=======================================================================
+|ECS disabled |ECS v1, v8 |Description
+|[@metadata][host_protocol]    |[@metadata][input][snmp][host][protocol]    |The protocol used to retrieve data e.g. "udp"
+|[@metadata][host_address]     |[@metadata][input][snmp][host][address]     |The host IP e.g. "192.168.1.1"
+|[@metadata][host_port]        |[@metadata][input][snmp][host][port]        |The host's port e.g. "161"
+|[@metadata][host_community]   |[@metadata][input][snmp][host][community]   |The configured community e.g. "public"
+|[host]                        |N/A                                         |Same as `[@metadata][host_address]`, no longer set in ECS mode
+|=======================================================================
+
 [id="plugins-{type}s-{plugin}-import-mibs"]
 ==== Importing MIBs 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -343,7 +343,7 @@ The `security_name` option specifies the SNMPv3 security name or user name.
   * There is no default value for this setting
 
 The `security_level` option specifies the SNMPv3 security level between
-Authentication, No Privacy; Authentication, Privacy; or no Authentication, no Privacy
+Authentication, No Privacy; Authentication, Privacy; or no Authentication, no Privacy. 
 
 [id="plugins-{type}s-{plugin}-target"]
 ===== `target`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,6 +26,7 @@ to gather information related to the current state of the devices operation.
 
 The SNMP input plugin supports SNMP v1, v2c, and v3 over UDP and TCP transport protocols.
 
+[id="plugins-{type}s-{plugin}-ecs"]
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 Because SNMP data has specific field names based on OIDs, we recommend setting a <<plugins-{type}s-{plugin}-target>>.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -28,8 +28,8 @@ The SNMP input plugin supports SNMP v1, v2c, and v3 over UDP and TCP transport p
 
 ==== Compatibility with the Elastic Common Schema (ECS)
 
-Since SNMP data has specific field names, based on OIDs, we recommend setting a <<plugins-{type}s-{plugin}-target>>.
-Meta-data fields started following a naming convention when <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> in enabled.
+Because SNMP data has specific field names based on OIDs, we recommend setting a <<plugins-{type}s-{plugin}-target>>.
+Metadata fields follow a specific naming convention when <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled.
 
 [cols="<l,<l,e,<e"]
 |=======================================================================

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -356,6 +356,7 @@ If not specified data will be stored in the root of the event.
 
 Setting a target is recommended when <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled.
 
+[id="plugins-{type}s-{plugin}-examples"]
 ==== Configuration examples
 
 *Specifying SNMPv3 settings*

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -55,6 +55,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-get>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-hosts>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
@@ -63,6 +64,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-oid_path_length>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-walk>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-tables>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 |=======================================================================
 
 ==== SNMPv3 Authentication Options
@@ -86,13 +88,13 @@ Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options suppo
 input plugins.
 
 [id="plugins-{type}s-{plugin}-get"]
-===== `get` 
+===== `get`
+
+  * Value type is <<array,array>>
+  * There is no default value for this setting
 
 Use the `get` option to query for scalar values for the given OID(s).
 One or more OID(s) are specified as an array of strings of OID(s).
-
-* Value type is <<array,array>>
-* There is no default value for this setting
 
 Example
 [source,ruby]
@@ -108,13 +110,13 @@ input {
 [id="plugins-{type}s-{plugin}-hosts"]
 ===== `hosts`
 
+  * Value type is <<array,array>>
+  * There is no default value for this setting
+
 The `hosts` option specifies the list of hosts to query the configured `get` and `walk` options.
 
 Each host definition is a hash and must define the `host` key and value.
 `host` must use the format `{tcp|udp}:{ip address}/{port}`, for example `host => "udp:127.0.0.1/161"`
-
-* Value type is <<array,array>>
-* There is no default value for this setting
 
 Each host definition can optionally include the following keys and values:
 
@@ -160,56 +162,57 @@ input {
 -----
 
 [id="plugins-{type}s-{plugin}-interval"]
-===== `interval` 
+===== `interval`
+
+  * Value type is <<number,number>>
+  * Default value is `30`
 
 The `interval` option specifies the polling interval in seconds.
 If polling all configured hosts takes longer than this interval, a warning will be emitted to the logs.
 
-* Value type is <<number,number>>
-* Default value is `30`
-
 [id="plugins-{type}s-{plugin}-mib_paths"]
-===== `mib_paths` 
+===== `mib_paths`
 
-The `mib_paths` option specifies the location of one or more imported MIB files. The value can be either a dir path containing
-the imported MIB `.dic` files or a file path to a single MIB `.dic` file.
+  * Value type is <<path,path>>
+  * There is no default value for this setting
 
-* Value type is <<path,path>>
-* There is no default value for this setting
+The `mib_paths` option specifies the location of one or more imported MIB files.
+The value can be either a dir path containing the imported MIB `.dic` files or a
+file path to a single MIB `.dic` file.
 
 This plugin includes the IETF MIBs.
 If you require other MIBs, you need to import them. See <<plugins-{type}s-{plugin}-import-mibs>>.
 
 [id="plugins-{type}s-{plugin}-oid_root_skip"]
-===== `oid_root_skip` 
+===== `oid_root_skip`
+
+  * Value type is <<number,number>>
+  * Default value is `0`
 
 The `oid_root_skip` option specifies the number of OID root digits to ignore in the event field name.
 For example, in a numeric OID like "1.3.6.1.2.1.1.1.0" the first 5 digits could be ignored by setting `oid_root_skip => 5`
 which would result in a field name "1.1.1.0". Similarly when a MIB is used an OID such
 "1.3.6.1.2.mib-2.system.sysDescr.0" would become "mib-2.system.sysDescr.0"
 
-* Value type is <<number,number>>
-* Default value is `0`
-
 [id="plugins-{type}s-{plugin}-oid_path_length"]
 ===== `oid_path_length`
+
+  * Value type is <<number,number>>
+  * Default value is `0`
 
 The `oid_path_length` option specifies the number of OID root digits to retain in the event field name.
 For example, in a numeric OID like "1.3.6.1.2.1.1.1.0" the last 2 digits could be retained by setting `oid_path_length => 2`
 which would result in a field name "1.0". Similarly when a MIB is used an OID such
 "1.3.6.1.2.mib-2.system.sysDescr.0" would become "sysDescr.0"
 
-* Value type is <<number,number>>
-* Default value is `0`
-
 [id="plugins-{type}s-{plugin}-walk"]
 ===== `walk`
 
+  * Value type is <<array,array>>
+  * There is no default value for this setting
+
 Use the `walk` option to retrieve the subtree of information for the given OID(s).
 One or more OID(s) are specified as an array of strings of OID(s).
-
-* Value type is <<array,array>>
-* There is no default value for this setting
 
 Queries the subtree of information starting at the given OID(s).
 
@@ -226,13 +229,13 @@ Example
 [id="plugins-{type}s-{plugin}-tables"]
 ===== `tables`
 
+  * Value type is <<array,array>>
+  * There is no default value for this setting
+  * Results are returned under a field using the table name
+
 The `tables` option is used to query for tabular values for the given column OID(s).
 
 Each table definition is a hash and must define the name key and value and the columns to return.
-
-* Value type is <<array,array>>
-* There is no default value for this setting
-* Results are returned under a field using the table name
 
 *Specifying a single table*
 
@@ -267,10 +270,10 @@ These options are required only if you are using SNMPv3.
 [id="plugins-{type}s-{plugin}-auth_pass"]
 ===== `auth_pass`
 
-The `auth_pass` option specifies the SNMPv3 authentication passphrase or password
+  * Value type is <<password,password>>
+  * There is no default value for this setting
 
-* Value type is <<password,password>>
-* There is no default value for this setting
+The `auth_pass` option specifies the SNMPv3 authentication passphrase or password.
 
 [id="plugins-{type}s-{plugin}-auth_protocol"]
 ===== `auth_protocol`
@@ -280,38 +283,65 @@ The `auth_protocol` option specifies the SNMPv3 authentication protocol or type
 * Value can be any of: `md5`, `sha`, `sha2`, `hmac128sha224`, `hmac192sha256`, `hmac256sha384`, `hmac384sha512`
 * There is no default value for this setting
 
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
+    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, JMS specific properties)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+
 [id="plugins-{type}s-{plugin}-priv_pass"]
 ===== `priv_pass`
 
-The `priv_pass` option specifies the SNMPv3 encryption password
+  * Value type is <<password,password>>
+  * There is no default value for this setting
 
-* Value type is <<password,password>>
-* There is no default value for this setting
+The `priv_pass` option specifies the SNMPv3 encryption password.
 
 [id="plugins-{type}s-{plugin}-priv_protocol"]
 ===== `priv_protocol`
 
-The `priv_protocol` option specifies the SNMPv3 privacy/encryption protocol.
+  * Value can be any of: `des`, `3des`, `aes`, `aes128`, `aes192`, `aes256`
+  * Note that `aes` and `aes128` are equivalent
+  * There is no default value for this setting
 
-* Value can be any of: `des`, `3des`, `aes`, `aes128`, `aes192`, `aes256`
-* Note that `aes` and `aes128` are equivalent
-* There is no default value for this setting
+The `priv_protocol` option specifies the SNMPv3 privacy/encryption protocol.
 
 [id="plugins-{type}s-{plugin}-security_name"]
 ===== `security_name`
 
-The `security_name` option specifies the SNMPv3 security name or user name
+  * Value type is <<string,string>>
+  * There is no default value for this setting
 
-* Value type is <<string,string>>
-* There is no default value for this setting
+The `security_name` option specifies the SNMPv3 security name or user name.
 
 [id="plugins-{type}s-{plugin}-security_level"]
 ===== `security_level`
 
-The `security_level` option specifies the SNMPv3 security level between Authentication, No Privacy; Authentication, Privacy; or no Authentication, no Privacy
+  * Value can be any of: `noAuthNoPriv`, `authNoPriv`, `authPriv`
+  * There is no default value for this setting
 
-* Value can be any of: `noAuthNoPriv`, `authNoPriv`, `authPriv`
-* There is no default value for this setting
+The `security_level` option specifies the SNMPv3 security level between
+Authentication, No Privacy; Authentication, Privacy; or no Authentication, no Privacy
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting
+
+The name of the field under which SNMP payloads are assigned.
+If not specified data will be stored in the root of the event.
+
+Setting a target is recommended when <<plugins-{type}s-{plugin}-ecs_compatibility>> enabled.
+
+==== Configuration examples
 
 *Specifying SNMPv3 settings*
 
@@ -331,8 +361,6 @@ input {
 }
 
 -----
-
-==== More configuration examples
 
 *Using both `get` and `walk` in the same poll cycle for each host(s)*
 

--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -151,7 +151,7 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
       # TODO: move these validations in a custom validator so it happens before the register method is called.
       host_details = host_name.match(HOST_REGEX)
       raise(LogStash::ConfigurationError, "invalid format for host option '#{host_name}'") unless host_details
-      raise(LogStash::ConfigurationError, "unsupported protocol for host option '#{host_name}'") unless host_details[:host_protocol].to_s =~ /^(?:udp|tcp|tls)$/i
+      raise(LogStash::ConfigurationError, "only udp & tcp protocols are supported for host option '#{host_name}'") unless host_details[:host_protocol].to_s =~ /^(?:udp|tcp)$/i
 
       protocol = host_details[:host_protocol]
       address = host_details[:host_address]

--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -115,15 +115,16 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
   def initialize(params={})
     super(params)
 
-    # Add the default "host" field to the event, for backwards compatibility
-    unless params.key?('add_field')
-      @add_field = ecs_select[disabled: { "host" => "%{[@metadata][host_address]}" }, v1: {}]
-    end
-
     @host_protocol_field = ecs_select[disabled: '[@metadata][host_protocol]', v1: '[@metadata][input][snmp][host][protocol]']
     @host_address_field = ecs_select[disabled: '[@metadata][host_address]', v1: '[@metadata][input][snmp][host][address]']
     @host_port_field = ecs_select[disabled: '[@metadata][host_port]', v1: '[@metadata][input][snmp][host][port]']
     @host_community_field = ecs_select[disabled: '[@metadata][host_community]', v1: '[@metadata][input][snmp][host][community]']
+
+    # Add the default "host" field to the event, for backwards compatibility, or host.ip in ecs mode
+    unless params.key?('add_field')
+      host_ip_field = ecs_select[disabled: "host", v1: "[host][ip]"]
+      @add_field = { host_ip_field => "%{#{@host_address_field}}" }
+    end
   end
 
   def register

--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -23,6 +23,8 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
 
   include LogStash::PluginMixins::EventSupport::EventFactoryAdapter
 
+  extend LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapter
+
   config_name "snmp"
 
   # List of OIDs for which we want to retrieve the scalar value

--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -7,11 +7,19 @@ require_relative "snmp/client"
 require_relative "snmp/clientv3"
 require_relative "snmp/mib"
 
+require 'logstash/plugin_mixins/ecs_compatibility_support'
+require 'logstash/plugin_mixins/event_support/event_factory_adapter'
+
 # Generate a repeating message.
 #
 # This plugin is intented only as an example.
 
 class LogStash::Inputs::Snmp < LogStash::Inputs::Base
+
+  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
+
+  include LogStash::PluginMixins::EventSupport::EventFactoryAdapter
+
   config_name "snmp"
 
   # List of OIDs for which we want to retrieve the scalar value
@@ -202,7 +210,7 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
           }
           result["@metadata"] = metadata
 
-          event = LogStash::Event.new(result)
+          event = event_factory.new_event(result)
           decorate(event)
           queue << event
         end

--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -75,9 +75,6 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
   # The default, `30`, means poll each host every 30 seconds.
   config :interval, :validate => :number, :default => 30
 
-  # Add the default "host" field to the event.
-  config :add_field, :validate => :hash, :default => { "host" => "%{[@metadata][host_address]}" }
-
   # SNMPv3 Credentials
   #
   # A single user can be configured and will be used for all defined SNMPv3 hosts.
@@ -104,6 +101,15 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
 
   BASE_MIB_PATH = ::File.join(__FILE__, "..", "..", "..", "mibs")
   PROVIDED_MIB_PATHS = [::File.join(BASE_MIB_PATH, "logstash"), ::File.join(BASE_MIB_PATH, "ietf")].map { |path| ::File.expand_path(path) }
+
+  def initialize(params={})
+    super(params)
+
+    # Add the default "host" field to the event, for backwards compatibility
+    unless params.key?('add_field')
+      @add_field = ecs_select[disabled: { "host" => "%{[@metadata][host_address]}" }, v1: {}]
+    end
+  end
 
   def register
     validate_oids!

--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -146,7 +146,7 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
       # TODO: move these validations in a custom validator so it happens before the register method is called.
       host_details = host_name.match(HOST_REGEX)
       raise(LogStash::ConfigurationError, "invalid format for host option '#{host_name}'") unless host_details
-      raise(LogStash::ConfigurationError, "only udp & tcp protocols are supported for host option '#{host_name}'") unless host_details[:host_protocol].to_s =~ /^(?:udp|tcp)$/i
+      raise(LogStash::ConfigurationError, "unsupported protocol for host option '#{host_name}'") unless host_details[:host_protocol].to_s =~ /^(?:udp|tcp|tls)$/i
 
       protocol = host_details[:host_protocol]
       address = host_details[:host_address]
@@ -244,7 +244,7 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
   private
 
   OID_REGEX = /^\.?([0-9\.]+)$/
-  HOST_REGEX = /^(?<host_protocol>udp|tcp):(?<host_address>.+)\/(?<host_port>\d+)$/i
+  HOST_REGEX = /^(?<host_protocol>\w+):(?<host_address>.+)\/(?<host_port>\d+)$/i
   VERSION_REGEX =/^1|2c|3$/
 
   def validate_oids!

--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -191,7 +191,8 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
           begin
             result = result.merge(client.get(oids, @oid_root_skip, @oid_path_length))
           rescue => e
-            logger.error("error invoking get operation on #{definition[:host_address]} for OIDs: #{oids}, ignoring", :exception => e, :backtrace => e.backtrace)
+            logger.error("error invoking get operation for OIDs: #{oids}, ignoring",
+                         host: definition[:host_address], exception: e, backtrace: e.backtrace)
           end
         end
         if !definition[:walk].empty?
@@ -199,7 +200,8 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
             begin
               result = result.merge(client.walk(oid, @oid_root_skip, @oid_path_length))
             rescue => e
-              logger.error("error invoking walk operation on OID: #{oid}, ignoring", :exception => e, :backtrace => e.backtrace)
+              logger.error("error invoking walk operation on OID: #{oid}, ignoring",
+                           host: definition[:host_address], exception: e, backtrace: e.backtrace)
             end
           end
         end
@@ -209,7 +211,8 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
             begin
               result = result.merge(client.table(table_entry, @oid_root_skip, @oid_path_length))
             rescue => e
-              logger.error("error invoking table operation on OID: #{table_entry['name']}, ignoring", :exception => e, :backtrace => e.backtrace)
+              logger.error("error invoking table operation on OID: #{table_entry['name']}, ignoring",
+                           host: definition[:host_address], exception: e, backtrace: e.backtrace)
             end
           end
         end
@@ -222,6 +225,8 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
           event.set(@host_community_field, definition[:host_community])
           decorate(event)
           queue << event
+        else
+          logger.debug? && logger.debug("no snmp data retrieved", host: definition[:host_address])
         end
       end
     end

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -20,8 +20,11 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'
+
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'rspec-wait'
 end

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'
 

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '1.2.8'
+  s.version       = '1.3.0'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -161,13 +161,13 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
         expect(event.get("[@metadata][host_address]")).to eq("127.0.0.1")
         expect(event.get("[@metadata][host_port]")).to eq("161")
         expect(event.get("[@metadata][host_community]")).to eq("public")
-        expect(event.get("host")).to eq("127.0.0.1")
+        expect(event.get("host")).to eql("127.0.0.1")
       else
         expect(event.get("[@metadata][input][snmp][host][protocol]")).to eq("udp")
         expect(event.get("[@metadata][input][snmp][host][address]")).to eq("127.0.0.1")
         expect(event.get("[@metadata][input][snmp][host][port]")).to eq('161')
         expect(event.get("[@metadata][input][snmp][host][community]")).to eq("public")
-        expect(event.include?("host")).to be false
+        expect(event.get("host")).to eql('ip' => "127.0.0.1")
       end
     end
 

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -191,14 +191,14 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
           input {
             snmp {
               get => ["1.3.6.1.2.1.1.1.0"]
-              hosts => [{ host => "tls:192.168.1.11/1161" }]
+              hosts => [{ host => "tcp:192.168.1.11/1161" }]
               add_field => { "[host][formatted]" => "%{[@metadata][input][snmp][host][protocol]}://%{[@metadata][input][snmp][host][address]}:%{[@metadata][input][snmp][host][port]}" }
             }
           }
       CONFIG
       event = input(config) { |_, queue| queue.pop }
 
-      expect(event.get("host")).to eq('formatted' => "tls://192.168.1.11:1161")
+      expect(event.get("host")).to eq('formatted' => "tcp://192.168.1.11:1161")
     end if ecs_select.active_mode != :disabled
   end
 

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -171,7 +171,7 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
       end
     end
 
-    it "shoud add custom host field (legacy metadata)" do
+    it "should add custom host field (legacy metadata)" do
       config = <<-CONFIG
           input {
             snmp {
@@ -186,7 +186,7 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
       expect(event.get("host")).to eq("udp:127.0.0.1/161,public")
     end if ecs_select.active_mode == :disabled
 
-    it "shoud add custom host field (ECS mode)" do
+    it "should add custom host field (ECS mode)" do
       config = <<-CONFIG
           input {
             snmp {
@@ -200,6 +200,22 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
 
       expect(event.get("host")).to eq('formatted' => "tcp://192.168.1.11:1161")
     end if ecs_select.active_mode != :disabled
+
+    it "should target event data" do
+      config = <<-CONFIG
+          input {
+            snmp {
+              get => ["1.3.6.1.2.1.1.1.0"]
+              hosts => [{ host => "udp:127.0.0.1/161" community => "public" }]
+              target => "snmp_data"
+            }
+          }
+      CONFIG
+      event = input(config) { |_, queue| queue.pop }
+
+      expect( event.include?('foo') ).to be false
+      expect( event.get('[snmp_data]') ).to eql 'foo' => 'bar'
+    end
   end
 
   context "StoppableIntervalRunner" do


### PR DESCRIPTION
The plugin had a `add_field, :validate => :hash, :default => { "host" => "%{[@metadata][host_address]}" }` default.
This will cause conflicts in ECS mode.

In ECS mode setting the `host` simply does not happen (no `add_field` default setting) and we just re-map the host metadata
e.g.`[@metadata][host_address]` (legacy) -> `[@metadata][input][snmp][host][address]` (ecs)

## Release notes



## What does this PR do?

Introduces an `ecs_compatibility` setting which causes the plugin to no longer set the `host` field.

## Why is it important/What is the impact to the user?

Improving ECS compliance.

## Author's Checklist

- [x] anything else we want to do with produces (SNMP) fields? possibly having a `target` :heavy_check_mark: 
- [x] ~~would we rather map SNMP host information (in ECS mode) to schema fields~~ :no_entry: 
  - `[@metadata][input][snmp][host][address]` -> `source.address` (probably always an IP)
  - `[@metadata][input][snmp][host][port]` -> `source.port`
  - `[@metadata][input][snmp][host][protocol]` -> `network.protocol`
  - `[@metadata][input][snmp][host][community]` no ECS mapping -> stays as is
- [x] documentation

## Related issues

- #47 
