### PR TITLE
interval: only sleep off remainder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.8
+  - Fixed interval handling to only sleep off the _remainder_ of the interval (if any), and to log a helpful warning when crawling the hosts takes longer than the configured interval [#61](https://github.com/logstash-plugins/logstash-input-snmp/issues/61)
+
 ## 1.2.7
   - Added integration tests to ensure SNMP server and IPv6 connections [#87](https://github.com/logstash-plugins/logstash-input-snmp/pull/87)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -163,6 +163,7 @@ input {
 ===== `interval` 
 
 The `interval` option specifies the polling interval in seconds.
+If polling all configured hosts takes longer than this interval, a warning will be emitted to the logs.
 
 * Value type is <<number,number>>
 * Default value is `30`

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '1.2.7'
+  s.version       = '1.2.8'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -253,7 +253,7 @@ describe LogStash::Inputs::Snmp do
 
           timestamps.each_cons(2) do |previous, current|
             # ensure each start time is very close to 1s after the previous.
-            expect(current - previous).to be_within(0.02).of(1)
+            expect(current - previous).to be_within(0.05).of(1)
           end
 
           thread.kill if thread.alive?


### PR DESCRIPTION
Attempt to adhere to the interval, regardless of how long execution takes.
After executing, sleep off only the _remainder_ of the interval (if any), and
log a helpful warning when execution takes longer than the interval.

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fixes issues related to fetching SNMP data at a periodic interval. The plugin now only sleeps off the _remainder_ of the interval between runs, and logs a helpful warning when execution takes longer than the configured interval.

## What does this PR do?

Introduces and tests a new `StoppableIntervalRunner`, which is used to run the crawler at a periodic interval. The implementation respects the stop-status of the plugin, and uses the plugin's logger to warn when execution takes longer than the configured interval.

## Why is it important/What is the impact to the user?

Ensures that the `interval` option supports actually collecting SNMP data at that periodic interval. When this plugin is configured with a 5-minute interval (`interval => 300`), and a number of hosts that take anywhere from 3-seconds to 1-minute to fetch data from, this ensures that the _start_ of each crawl is correctly 5-minutes apart.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

Resolves: https://github.com/logstash-plugins/logstash-input-snmp/issues/61

## Logs

When the interval cannot be satisfied, a helpful log message is emitted:

~~~
[2021-09-14T17:54:05,585][WARN ][logstash.input.snmp    ][my-snmp-pipeline] polling hosts took longer than the configured interval {:interval_seconds=>30, :duration_seconds=>37.019}
~~~