### PR TITLE
fix: Specifically cast passed in retries and timeout values to ints

### DIFF
--- a/lib/logstash/inputs/snmp.rb
+++ b/lib/logstash/inputs/snmp.rb
@@ -126,8 +126,8 @@ class LogStash::Inputs::Snmp < LogStash::Inputs::Base
       version = host["version"] || "2c"
       raise(LogStash::ConfigurationError, "only protocol version '1', '2c' and '3' are supported for host option '#{host_name}'") unless version =~ VERSION_REGEX
 
-      retries = host["retries"] || 2
-      timeout = host["timeout"] || 1000
+      retries = host["retries"]&.to_i || 2
+      timeout = host["timeout"]&.to_i || 1000
 
       # TODO: move these validations in a custom validator so it happens before the register method is called.
       host_details = host_name.match(HOST_REGEX)


### PR DESCRIPTION
## Release notes

- Fix issue where interval and retries can't be set using ENV variables. Using an ENV variable to set these values will result in the logs given below.

## What does this PR do?

Specifically cast the `retries` and `interval` settings in the `host` array to integers. Since there's no validation on these values, if you set these values through ENV variables, they'll come through as strings.

## Why is it important/What is the impact to the user?

Users will like to set these values through ENV variables.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works


## How to test this PR locally

- Use ENV variables to set the retries and interval values in the config:

```
input {
    snmp {
        hosts => [
            {host => "udp:127.0.0.1" community => "public" retries => '${RETRIES:2}' timeout => '${TIMEOUT:5000}' }
```

## Related issues

None created

## Logs

```
Pipeline error {:pipeline_id=>"inventory-input", :exception=>#<TypeError: cannot convert instance of class org.jruby.RubyString to int>, :backtrace=>[
	"/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-snmp-1.2.7/lib/logstash/inputs/snmp/client.rb:48:in `build_target'",
	"/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-snmp-1.2.7/lib/logstash/inputs/snmp/client.rb:25:in `initialize'",
	"/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-snmp-1.2.7/lib/logstash/inputs/snmp.rb:157:in `block in register'",
	"org/jruby/RubyArray.java:1809:in `each'",
	"/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-snmp-1.2.7/lib/logstash/inputs/snmp.rb:123:in `register'",
	"/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:228:in `block in register_plugins'",
	"org/jruby/RubyArray.java:1809:in `each'",
	"/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:227:in `register_plugins'",
	"/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:386:in `start_inputs'",
	"/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:311:in `start_workers'",
	"/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:185:in `run'",
	"/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:137:in `block in start'"
], "pipeline.sources"=>["/usr/share/logstash/pipeline/inventory.conf"], :thread=>"#<Thread:0x567073ec@/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:125 run>"}
```
