### PR TITLE
Refactor: handle no response(s) wout error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.1
+  -  Refactor: handle no response(s) wout error logging [#105](https://github.com/logstash-plugins/logstash-input-snmp/pull/105)
+
 ## 1.3.0
   - Feat: ECS compliance + optional target [#99](https://github.com/logstash-plugins/logstash-input-snmp/pull/99)
   - Internal: update to Gradle 7 [#102](https://github.com/logstash-plugins/logstash-input-snmp/pull/102)

--- a/lib/logstash/inputs/snmp/base_client.rb
+++ b/lib/logstash/inputs/snmp/base_client.rb
@@ -52,12 +52,12 @@ module LogStash
     end
 
     def walk(oid, strip_root = 0, path_length = 0)
-      result = {}
-
       pdufactory = get_pdu_factory
       treeUtils = TreeUtils.new(@snmp, pdufactory)
       events = treeUtils.getSubtree(@target, OID.new(oid))
       return nil if events.nil? || events.size == 0
+
+      result = {}
 
       events.each do |event|
         next if event.nil?

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '1.3.0'
+  s.version       = '1.3.1'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -242,6 +242,7 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
           }
         CONFIG
         queue = input(config) { |_, queue| queue }
+        sleep(0.25) # a bit until run -> client.get executes
 
         expect( queue.size ).to eql 0
       end
@@ -269,6 +270,7 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
           }
         CONFIG
         queue = input(config) { |_, queue| queue }
+        sleep(0.25) # a bit until run -> client.table executes
 
         expect( queue.size ).to eql 0
       end

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -242,7 +242,7 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
           }
         CONFIG
         queue = input(config) { |_, queue| queue }
-        sleep(0.25) # a bit until run -> client.get executes
+        sleep(0.5) # a bit until run -> client.get executes
 
         expect( queue.size ).to eql 0
       end
@@ -270,7 +270,7 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
           }
         CONFIG
         queue = input(config) { |_, queue| queue }
-        sleep(0.25) # a bit until run -> client.table executes
+        sleep(0.5) # a bit until run -> client.table executes
 
         expect( queue.size ).to eql 0
       end

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -224,11 +224,13 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
 
     context 'mocked nil get response' do
 
+      let(:logger) { double("Logger").as_null_object }
+
       before do
         expect(mock_client).to receive(:get).once.and_return(nil)
+        allow_any_instance_of(described_class).to receive(:logger).and_return(logger)
+        expect(logger).not_to receive(:error)
       end
-
-      let(:logger) { plugin.logger }
 
       it 'generates no events when client (on get) returns no response' do
         config = <<-CONFIG

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -136,43 +136,46 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
 
     before(:each) do
       allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
-    end
 
-    before do
       expect(LogStash::SnmpClient).to receive(:new).and_return(mock_client)
-      expect(mock_client).to receive(:get).and_return({"foo" => "bar"})
       # devutils in v6 calls close on the test pipelines while it does not in v7+
-      expect(mock_client).to receive(:close).at_most(:once)
+      allow(mock_client).to receive(:close).at_most(:once)
     end
 
-    it "shoud add @metadata fields and add default host field" do
-      config = <<-CONFIG
+    context 'mocked get' do
+
+      before do
+        expect(mock_client).to receive(:get).and_return({"foo" => "bar"})
+      end
+
+      it "shoud add @metadata fields and add default host field" do
+        config = <<-CONFIG
           input {
             snmp {
               get => ["1.3.6.1.2.1.1.1.0"]
               hosts => [{ host => "udp:127.0.0.1/161" community => "public" }]
             }
           }
-      CONFIG
-      event = input(config) { |_, queue| queue.pop }
+        CONFIG
+        event = input(config) { |_, queue| queue.pop }
 
-      if ecs_select.active_mode == :disabled
-        expect(event.get("[@metadata][host_protocol]")).to eq("udp")
-        expect(event.get("[@metadata][host_address]")).to eq("127.0.0.1")
-        expect(event.get("[@metadata][host_port]")).to eq("161")
-        expect(event.get("[@metadata][host_community]")).to eq("public")
-        expect(event.get("host")).to eql("127.0.0.1")
-      else
-        expect(event.get("[@metadata][input][snmp][host][protocol]")).to eq("udp")
-        expect(event.get("[@metadata][input][snmp][host][address]")).to eq("127.0.0.1")
-        expect(event.get("[@metadata][input][snmp][host][port]")).to eq('161')
-        expect(event.get("[@metadata][input][snmp][host][community]")).to eq("public")
-        expect(event.get("host")).to eql('ip' => "127.0.0.1")
+        if ecs_select.active_mode == :disabled
+          expect(event.get("[@metadata][host_protocol]")).to eq("udp")
+          expect(event.get("[@metadata][host_address]")).to eq("127.0.0.1")
+          expect(event.get("[@metadata][host_port]")).to eq("161")
+          expect(event.get("[@metadata][host_community]")).to eq("public")
+          expect(event.get("host")).to eql("127.0.0.1")
+        else
+          expect(event.get("[@metadata][input][snmp][host][protocol]")).to eq("udp")
+          expect(event.get("[@metadata][input][snmp][host][address]")).to eq("127.0.0.1")
+          expect(event.get("[@metadata][input][snmp][host][port]")).to eq('161')
+          expect(event.get("[@metadata][input][snmp][host][community]")).to eq("public")
+          expect(event.get("host")).to eql('ip' => "127.0.0.1")
+        end
       end
-    end
 
-    it "should add custom host field (legacy metadata)" do
-      config = <<-CONFIG
+      it "should add custom host field (legacy metadata)" do
+        config = <<-CONFIG
           input {
             snmp {
               get => ["1.3.6.1.2.1.1.1.0"]
@@ -180,14 +183,14 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
               add_field => { host => "%{[@metadata][host_protocol]}:%{[@metadata][host_address]}/%{[@metadata][host_port]},%{[@metadata][host_community]}" }
             }
           }
-      CONFIG
-      event = input(config) { |_, queue| queue.pop }
+        CONFIG
+        event = input(config) { |_, queue| queue.pop }
 
-      expect(event.get("host")).to eq("udp:127.0.0.1/161,public")
-    end if ecs_select.active_mode == :disabled
+        expect(event.get("host")).to eq("udp:127.0.0.1/161,public")
+      end if ecs_select.active_mode == :disabled
 
-    it "should add custom host field (ECS mode)" do
-      config = <<-CONFIG
+      it "should add custom host field (ECS mode)" do
+        config = <<-CONFIG
           input {
             snmp {
               get => ["1.3.6.1.2.1.1.1.0"]
@@ -195,14 +198,14 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
               add_field => { "[host][formatted]" => "%{[@metadata][input][snmp][host][protocol]}://%{[@metadata][input][snmp][host][address]}:%{[@metadata][input][snmp][host][port]}" }
             }
           }
-      CONFIG
-      event = input(config) { |_, queue| queue.pop }
+        CONFIG
+        event = input(config) { |_, queue| queue.pop }
 
-      expect(event.get("host")).to eq('formatted' => "tcp://192.168.1.11:1161")
-    end if ecs_select.active_mode != :disabled
+        expect(event.get("host")).to eq('formatted' => "tcp://192.168.1.11:1161")
+      end if ecs_select.active_mode != :disabled
 
-    it "should target event data" do
-      config = <<-CONFIG
+      it "should target event data" do
+        config = <<-CONFIG
           input {
             snmp {
               get => ["1.3.6.1.2.1.1.1.0"]
@@ -210,12 +213,38 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
               target => "snmp_data"
             }
           }
-      CONFIG
-      event = input(config) { |_, queue| queue.pop }
+        CONFIG
+        event = input(config) { |_, queue| queue.pop }
 
-      expect( event.include?('foo') ).to be false
-      expect( event.get('[snmp_data]') ).to eql 'foo' => 'bar'
+        expect( event.include?('foo') ).to be false
+        expect( event.get('[snmp_data]') ).to eql 'foo' => 'bar'
+      end
+
     end
+
+    context 'mocked nil get response' do
+
+      before do
+        expect(mock_client).to receive(:get).once.and_return(nil)
+      end
+
+      let(:logger) { plugin.logger }
+
+      it 'generates no events when client (on get) returns no response' do
+        config = <<-CONFIG
+          input {
+            snmp {
+              get => ["1.3.6.1.2.1.1.1.0"]
+              hosts => [{ host => "udp:127.0.0.1/161" community => "public" }]
+            }
+          }
+        CONFIG
+        queue = input(config) { |_, queue| queue }
+
+        expect( queue.size ).to eql 0
+      end
+    end
+
   end
 
   context "StoppableIntervalRunner" do

--- a/spec/inputs/snmp_spec.rb
+++ b/spec/inputs/snmp_spec.rb
@@ -224,6 +224,13 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
 
     context 'mocked nil get response' do
 
+      let(:config) do
+        {
+            'get' => ["1.3.6.1.2.1.1.1.0"],
+            "hosts" => [{"host" => "udp:127.0.0.1/161", "community" => "public"}]
+        }
+      end
+
       let(:logger) { double("Logger").as_null_object }
 
       before do
@@ -233,22 +240,23 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
       end
 
       it 'generates no events when client returns no response' do
-        config = <<-CONFIG
-          input {
-            snmp {
-              get => ["1.3.6.1.2.1.1.1.0"]
-              hosts => [{ host => "udp:127.0.0.1/161" community => "public" }]
-            }
-          }
-        CONFIG
-        queue = input(config) { |_, queue| queue }
-        sleep(0.5) # a bit until run -> client.get executes
+        input = described_class.new(config).tap { |input| input.register }
+        input.poll_clients queue = Queue.new
 
         expect( queue.size ).to eql 0
       end
     end
 
     context 'mocked nil table response' do
+
+      let(:config) do
+        {
+            'tables' => [
+                { 'name' => "a1Table", 'columns' => ["1.3.6.1.4.1.3375.2.2.5.2.3.1.1"] }
+            ],
+            "hosts" => [{"host" => "udp:127.0.0.1/161", "community" => "public"}]
+        }
+      end
 
       let(:logger) { double("Logger").as_null_object }
 
@@ -259,24 +267,21 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
       end
 
       it 'generates no events when client returns no response' do
-        config = <<-CONFIG
-          input {
-            snmp {
-              tables => [ 
-                { name => "a1Table" "columns" => ["1.3.6.1.4.1.3375.2.2.5.2.3.1.1"] }
-              ]
-              hosts => [{ host => "udp:127.0.0.1/161" community => "public" }]
-            }
-          }
-        CONFIG
-        queue = input(config) { |_, queue| queue }
-        sleep(0.5) # a bit until run -> client.table executes
+        input = described_class.new(config).tap { |input| input.register }
+        input.poll_clients queue = Queue.new
 
         expect( queue.size ).to eql 0
       end
     end
 
     context 'mocked nil walk response' do
+
+      let(:config) do
+        {
+            'walk' => ["1.3.6.1.2.1.1"],
+            "hosts" => [{"host" => "udp:127.0.0.1/161", "community" => "public"}]
+        }
+      end
 
       let(:logger) { double("Logger").as_null_object }
 
@@ -287,16 +292,8 @@ describe LogStash::Inputs::Snmp, :ecs_compatibility_support do
       end
 
       it 'generates no events when client returns no response' do
-        config = <<-CONFIG
-          input {
-            snmp {
-              walk => ["1.3.6.1.2.1.1"]
-              hosts => [{ host => "udp:127.0.0.1/161" community => "public" }]
-            }
-          }
-        CONFIG
-        queue = input(config) { |_, queue| queue }
-        sleep(0.5) # a bit until run -> client.walk executes
+        input = described_class.new(config).tap { |input| input.register }
+        input.poll_clients queue = Queue.new
 
         expect( queue.size ).to eql 0
       end


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

Refactors response handling from SNMP client - in case of no response (`nil`) no error will happen and thus won't get logged.

## Why is it important/What is the impact to the user?

Example: when a table operation gets no data the [client returns `nil`](https://github.com/logstash-plugins/logstash-input-snmp/blob/v1.2.8/lib/logstash/inputs/snmp/base_client.rb#L99), that leads to [an error with `result.merge nil`](https://github.com/logstash-plugins/logstash-input-snmp/blob/v1.2.8/lib/logstash/inputs/snmp.rb#L189), which is than [logged](https://github.com/logstash-plugins/logstash-input-snmp/blob/v1.2.8/lib/logstash/inputs/snmp.rb#L191) and confusing the user ... the plugin continues to operate fine. A no response should not be considered a reason for logging an error.

## Author's Checklist

- [x] unit test(s)

## Logs

```
[ERROR] 2021-11-23 12:01:14.157 [[main]<snmp] snmp - error invoking table operation on OID: vEdge, ignoring {:exception=>#<TypeError: no implicit conversion of nil into Hash>, :backtrace=>["org/jruby/RubyHash.java:1902:in `merge!'", "org/jruby/RubyHash.java:1938:in `merge'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-snmp-1.2.8/lib/logstash/inputs/snmp.rb:189:in `block in run'", "org/jruby/RubyArray.java:1820:in `each'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-snmp-1.2.8/lib/logstash/inputs/snmp.rb:187:in `block in run'", "org/jruby/RubyArray.java:1820:in `each'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-snmp-1.2.8/lib/logstash/inputs/snmp.rb:167:in `block in run'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-snmp-1.2.8/lib/logstash/inputs/snmp.rb:327:in `every'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-snmp-1.2.8/lib/logstash/inputs/snmp.rb:166:in `run'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:405:in `inputworker'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:396:in `block in start_input'"]}
```
