### PR TITLE
[DOCS] add troubleshooting help for "failed to locate MIB" smidump error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.2
+  -  Docs: add troubleshooting help for "failed to locate MIB module" error when using smidump to convert MIBs
+
 ## 1.3.1
   -  Refactor: handle no response(s) wout error logging [#105](https://github.com/logstash-plugins/logstash-input-snmp/pull/105)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -63,6 +63,37 @@ $ smidump --level=1 -k -f python RFC1213-MIB > RFC1213-MIB.dic
 
 Note that the resulting file as output by `smidump` must have the `.dic` extension.
 
+As `smidump` only looks for mib dependencies in its pre-configured path lists as defined in the documentaion in the https://www.ibr.cs.tu-bs.de/projects/libsmi/smi_config.html["MODULES LOCATIONS"] section, you may need to provide the paths to locations of MIBs in your particular environment to avoid a `failed to locate MIB module` error.
+
+Two ways to achieve this are by using an environment variable or a config file to provide the additional path configuration.
+
+Set the `SMIPATH` env var with the path to your mibs ensuring you include a prepended colon `:` for the path, for example:
+
+[source,sh]
+-----
+$ SMIPATH=":/path/to/mibs/" smidump -k -f python CISCO-PROCESS-MIB.mib > CISCO-PROCESS-MIB_my.dic
+-----
+
+NOTE: SMI docs on the prepended colon:
+
+  The ‘path’ command argument and the environment variable either start with a path separator character (‘:’ on UNIX-like systems, ‘;’ on MS-Windows systems) to append to the path, or end with a path separator character to prepend to the path, or otherwise completely replace the path.
+
+
+The other way is to create a configuration file eg `smi.conf` with the `path` option.
+
+[source,sh]
+-----
+path :/path/to/mibs/
+-----
+
+and use that config with smidump:
+
+[source,sh]
+-----
+$ smidump -c smi.conf -k -f python CISCO-PROCESS-MIB.mib > CISCO-PROCESS-MIB_my.dic
+-----
+
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== SNMP Input Configuration Options
 

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '1.3.1'
+  s.version       = '1.3.2'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Release notes

Docs: Add troubleshooting steps for `failed to locate MIB module` error when using `smidump` to convert MIBs

## What does this PR do?

Provides a way forward if users get stuck seeing `failed to locate MIB module` when converting MIBs.

## Related issues

- Relates: #19
