### PR TITLE
Silence warnings when loading MIB dictionary files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.3
+  - Silence warnings when loading dictionary MIB files [#118](https://github.com/logstash-plugins/logstash-input-snmp/pull/118)
+
 ## 1.3.2
   -  [DOC] Add troubleshooting help for "failed to locate MIB module" error when using smidump to convert MIBs [#112](https://github.com/logstash-plugins/logstash-input-snmp/pull/112)
   -  Fix CI failures [#113](https://github.com/logstash-plugins/logstash-input-snmp/pull/113)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/log
 
 ## Developing
 
-### 1. Plugin Developement and Testing
+### 1. Plugin Development and Testing
 
 #### Code
 - To get started, you'll need JRuby with the Bundler gem installed.

--- a/lib/logstash/inputs/snmp/mib.rb
+++ b/lib/logstash/inputs/snmp/mib.rb
@@ -157,11 +157,21 @@ module LogStash
         sub('MIB =', 'mib =')
 
       mib = nil
-      eval(mib_hash)
+      silence_warnings do
+        eval(mib_hash)
+      end
       mib
     rescue Exception => e
       # rescuing Exception class is important here to rescue SyntaxError from eval
       raise(SnmpMibError, "error parsing mib dic file: #{filename}, error: #{e.message}")
+    end
+
+    def silence_warnings
+      warn_level = $VERBOSE
+      $VERBOSE = nil
+      yield
+    ensure
+      $VERBOSE = warn_level
     end
   end
 end

--- a/lib/logstash/inputs/snmp/mib.rb
+++ b/lib/logstash/inputs/snmp/mib.rb
@@ -166,9 +166,11 @@ module LogStash
       raise(SnmpMibError, "error parsing mib dic file: #{filename}, error: #{e.message}")
     end
 
+    # MIB definition files may have duplicate entries that, since Ruby 2.7, generate warnings when they are converted to a hash.
+    # This method will suppress these warnings, unless `debug` logging is enabled.
     def silence_warnings
       warn_level = $VERBOSE
-      $VERBOSE = nil
+      $VERBOSE = logger.debug? ? warn_level : nil
       yield
     ensure
       $VERBOSE = warn_level

--- a/logstash-input-snmp.gemspec
+++ b/logstash-input-snmp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp'
-  s.version       = '1.3.2'
+  s.version       = '1.3.3'
   s.licenses      = ['Apache-2.0']
   s.summary       = "SNMP input plugin"
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?
When running plugin, the plugin warns `(eval):XXXX: warning: key "XXXX" is duplicated and overwritten on line XXXX`. This change silences the warnings _ONLY_ when loading MIB dictionary files.

## Why is it important/What is the impact to the user?
Customers are getting this warnings serious. This wasn't warning before with ruby <2.6 versions and it seems from 2.7+ versions started warning when updating the id which hash object already has.
Additional notes,
- we convert MIB files into dictionary with `smidump --level=1 -k -f python RFC1213-MIB > RFC1213-MIB.dic` and I don't see any option to opt out the duplicate IDs.
- another way I could think is to utilize `Warning.extend` which [introduced in ruby 3.0.1](https://ruby-doc.org/core-3.0.1/Warning.html#method-i-warn) but firstly it didn't work at first try (maybe somewhere I had to include it?!) but main reason I afraid to make this change since it may affect to all other warning, also when it makes slower the application since we try to filter out with string match.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally
- clone and run with snmp configured pipeline

## Related issues

- Closes #111 

## Use cases

## Screenshots

## Logs
```
// Before the change
[2023-07-30T09:31:09,884][INFO ][logstash.inputs.snmp     ][main] using plugin provided MIB path /Users/mashhur/Dev/elastic/ls-plugins/logstash-input-snmp/lib/mibs/ietf
(eval):1426: warning: key "bfdSessDiag" is duplicated and overwritten on line 1423
(eval):1462: warning: key "bfdSessDiag" is duplicated and overwritten on line 1459
(eval):1658: warning: key "ipNetToMediaPhysAddress" is duplicated and overwritten on line 1663
(eval):2013: warning: key "mplsXCOperStatus" is duplicated and overwritten on line 2010
(eval):2049: warning: key "mplsXCOperStatus" is duplicated and overwritten on line 2046
(eval):1136: warning: key "ospfTrapControlGroup" is duplicated and overwritten on line 1133
(eval):2175: warning: key "pwOperStatus" is duplicated and overwritten on line 2172
(eval):2219: warning: key "pwOperStatus" is duplicated and overwritten on line 2216
(eval):1835: warning: key "rdbmsGroup" is duplicated and overwritten on line 1840
(eval):732: warning: key "rip2GlobalGroup" is duplicated and overwritten on line 729
(eval):732: warning: key "rip2IfStatGroup" is duplicated and overwritten on line 733
(eval):732: warning: key "rip2IfConfGroup" is duplicated and overwritten on line 737
(eval):732: warning: key "rip2PeerGroup" is duplicated and overwritten on line 741
(eval):3011: warning: key "slapmPolicyMonitorStatus" is duplicated and overwritten on line 3016
(eval):3063: warning: key "slapmPolicyMonitorStatus" is duplicated and overwritten on line 3068
(eval):3279: warning: key "slapmSubcomponentMonitorStatus" is duplicated and overwritten on line 3288
(eval):3337: warning: key "slapmSubcomponentMonitorStatus" is duplicated and overwritten on line 3346
(eval):3389: warning: key "slapmPRMonStatus" is duplicated and overwritten on line 3394
(eval):3441: warning: key "slapmPRMonStatus" is duplicated and overwritten on line 3446
(eval):3669: warning: key "slapmSubcomponentMonitorStatus" is duplicated and overwritten on line 3678
(eval):3727: warning: key "slapmSubcomponentMonitorStatus" is duplicated and overwritten on line 3736
[2023-07-30T09:31:15,810][INFO ][logstash.javapipeline    ][main] Pipeline started {"pipeline.id"=>"main"}
```

```
// after the change
[2023-07-30T09:55:15,433][INFO ][logstash.javapipeline    ][main] Pipeline Java execution initialization time {"seconds"=>0.2}
[2023-07-30T09:55:15,434][INFO ][logstash.inputs.snmp     ][main] using plugin provided MIB path /Users/mashhur/Dev/elastic/ls-plugins/logstash-input-snmp/lib/mibs/logstash
[2023-07-30T09:55:15,435][INFO ][logstash.inputs.snmp     ][main] using plugin provided MIB path /Users/mashhur/Dev/elastic/ls-plugins/logstash-input-snmp/lib/mibs/ietf
[2023-07-30T09:55:16,302][INFO ][logstash.javapipeline    ][main] Pipeline started {"pipeline.id"=>"main"}
[2023-07-30T09:55:16,314][INFO ][logstash.agent           ] Pipelines running {:count=>1, :running_pipelines=>[:main], :non_running_pipelines=>[]}
```